### PR TITLE
Fix overlap of the ViewPager on the bottom AppIntro bar

### DIFF
--- a/appintro/src/main/res/layout/appintro_fragment_intro.xml
+++ b/appintro/src/main/res/layout/appintro_fragment_intro.xml
@@ -3,8 +3,7 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingBottom="@dimen/appIntroBottomBarHeight">
+    android:orientation="vertical">
 
     <include layout="@layout/appintro_fragment_intro_content" />
 </LinearLayout>

--- a/appintro/src/main/res/layout/appintro_fragment_intro2.xml
+++ b/appintro/src/main/res/layout/appintro_fragment_intro2.xml
@@ -3,8 +3,7 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingBottom="@dimen/appIntro2BottomBarHeight">
+    android:orientation="vertical">
 
     <include layout="@layout/appintro_fragment_intro_content" />
 </LinearLayout>

--- a/appintro/src/main/res/layout/appintro_intro_layout.xml
+++ b/appintro/src/main/res/layout/appintro_intro_layout.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/appintro_default_background_color">
@@ -10,7 +9,9 @@
         android:id="@+id/view_pager"
         android:fitsSystemWindows="true"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_above="@+id/bottom"/>
 
     <LinearLayout
         android:id="@+id/bottom"

--- a/appintro/src/main/res/layout/appintro_intro_layout2.xml
+++ b/appintro/src/main/res/layout/appintro_intro_layout2.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="#222222">
@@ -15,7 +14,9 @@
         android:id="@+id/view_pager"
         android:fitsSystemWindows="true"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_above="@+id/bottom"/>
 
     <LinearLayout
         android:id="@+id/bottom"


### PR DESCRIPTION
Fixes #576

Making sure that the `ViewPager` is not overlapping the bar below. Also removing the extra padding and adding the proper layout rule.

| Before | After | 
| -- | -- |
| ![Imgur](https://i.imgur.com/YZV8jpv.png) | ![Imgur](https://i.imgur.com/GkWuIVQ.png) |


