### PR TITLE
Replace the Layout2 background color with the proper resource

### DIFF
--- a/appintro/src/main/res/layout/appintro_intro_layout2.xml
+++ b/appintro/src/main/res/layout/appintro_intro_layout2.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="#222222">
+    android:background="@color/appintro_default_background_color">
 
     <FrameLayout
         android:id="@+id/background"


### PR DESCRIPTION
Looks like this was left behind when working on #335

The background should be a resource so that developers can override it
eventually