### PR TITLE
Remove the 'v' from the version name in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ a previous version of the library that uses the **old Support Library** packages
 ```gradle
 	dependencies {
 	        // AndroidX Capable version
-	        implementation 'com.github.AppIntro:AppIntro:v5.1.0'
+	        implementation 'com.github.AppIntro:AppIntro:5.1.0'
 	        
 	        // *** OR ***
 	        
 	        // Support Library compatibility version 
-	        implementation 'com.github.AppIntro:AppIntro:v4.2.3'
+	        implementation 'com.github.AppIntro:AppIntro:4.2.3'
 	}
 ```
 


### PR DESCRIPTION
Fixes #621 

I've pushed new tags without a `v` prefix, and I'm updating the README so tools that rely on semantic versioning won't be broken.