### PR TITLE
[DRAFT] Add support for using PageIndicatorView

### DIFF
--- a/appintro-indicators/build.gradle
+++ b/appintro-indicators/build.gradle
@@ -1,0 +1,30 @@
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'maven'
+apply plugin: 'signing'
+apply from: 'maven-push.gradle'
+
+android {
+    compileSdkVersion 28
+
+    defaultConfig {
+        minSdkVersion 14
+        targetSdkVersion 28
+        versionCode 20
+        versionName "5.1.0"
+
+        consumerProguardFiles 'consumer-proguard-rules.pro'
+    }
+}
+
+dependencies {
+    implementation project(':appintro')
+    implementation 'androidx.appcompat:appcompat:1.0.2'
+
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "com.romandanylyk:pageindicatorview:1.0.3"
+}
+
+repositories {
+    mavenCentral()
+}

--- a/appintro-indicators/consumer-proguard-rules.pro
+++ b/appintro-indicators/consumer-proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.github.paolorotolo.** {*;}

--- a/appintro-indicators/gradle.properties
+++ b/appintro-indicators/gradle.properties
@@ -1,0 +1,17 @@
+POM_NAME=AppIntro
+POM_ARTIFACT_ID=appintro
+POM_PACKAGING=aar
+VERSION_NAME=4.1.0
+VERSION_CODE=13
+GROUP=com.github.paolorotolo
+
+POM_DESCRIPTION=AppIntro library
+POM_URL=https://github.com/PaoloRotolo/AppIntro
+POM_SCM_URL=https://github.com/PaoloRotolo/AppIntro
+POM_SCM_CONNECTION=git@github.com:PaoloRotolo/AppIntro.git
+POM_SCM_DEV_CONNECTION=git@github.com:PaoloRotolo/AppIntro.git
+POM_LICENCE_NAME=The Apache Software License, Version 2.0
+POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_DIST=repo
+POM_DEVELOPER_ID=paolorotolo
+POM_DEVELOPER_NAME=paolorotolo

--- a/appintro-indicators/maven-push.gradle
+++ b/appintro-indicators/maven-push.gradle
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2013 Chris Banes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'maven'
+apply plugin: 'signing'
+
+def isReleaseBuild() {
+        return VERSION_NAME.contains("SNAPSHOT") == false
+}
+
+def getReleaseRepositoryUrl() {
+        return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
+                        : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+}
+
+def getSnapshotRepositoryUrl() {
+        return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
+                        : "https://oss.sonatype.org/content/repositories/snapshots/"
+}
+
+def getRepositoryUsername() {
+        return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
+}
+
+def getRepositoryPassword() {
+        return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
+}
+
+afterEvaluate { project ->
+        uploadArchives {
+                repositories {
+                        mavenDeployer {
+                                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+                                pom.groupId = GROUP
+                                pom.artifactId = POM_ARTIFACT_ID
+                                pom.version = VERSION_NAME
+
+                                repository(url: getReleaseRepositoryUrl()) {
+                                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                                }
+                                snapshotRepository(url: getSnapshotRepositoryUrl()) {
+                                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                                }
+
+                                pom.project {
+                                        name POM_NAME
+                                        packaging POM_PACKAGING
+                                        description POM_DESCRIPTION
+                                        url POM_URL
+
+                                        scm {
+                                                url POM_SCM_URL
+                                                connection POM_SCM_CONNECTION
+                                                developerConnection POM_SCM_DEV_CONNECTION
+                                        }
+
+                                        licenses {
+                                                license {
+                                                        name POM_LICENCE_NAME
+                                                        url POM_LICENCE_URL
+                                                        distribution POM_LICENCE_DIST
+                                                }
+                                        }
+
+                                        developers {
+                                                developer {
+                                                        id POM_DEVELOPER_ID
+                                                        name POM_DEVELOPER_NAME
+                                                }
+                                        }
+                                }
+                        }
+                }
+        }
+
+        signing {
+                required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
+                sign configurations.archives
+        }
+
+        //task androidJavadocs(type: Javadoc) {
+                //source = android.sourceSets.main.allJava
+        //}
+
+        //task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+                //classifier = 'javadoc'
+                //from androidJavadocs.destinationDir
+        //}
+
+        task androidSourcesJar(type: Jar) {
+                classifier = 'sources'
+                from android.sourceSets.main.java.sourceFiles
+        }
+
+        artifacts {
+                archives androidSourcesJar
+        }
+}

--- a/appintro-indicators/src/main/AndroidManifest.xml
+++ b/appintro-indicators/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<manifest
+    package="com.github.paolorotolo.appintro.indicators">
+    <application />
+</manifest>

--- a/appintro-indicators/src/main/java/com/github/paolorotolo/appintro/indicator/PageIndicatorViewIndicatorController.kt
+++ b/appintro-indicators/src/main/java/com/github/paolorotolo/appintro/indicator/PageIndicatorViewIndicatorController.kt
@@ -1,0 +1,40 @@
+package com.github.paolorotolo.appintro.indicator
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import com.rd.PageIndicatorView
+import com.rd.animation.type.AnimationType
+
+class PageIndicatorViewIndicatorController(
+        context: Context,
+        attrs: AttributeSet? = null,
+        private val animationType: AnimationType = AnimationType.NONE
+) : PageIndicatorView(context, attrs), IndicatorController {
+
+    override var selectedIndicatorColor: Int = 0
+        set(value) {
+            field = value
+            this.selectedColor = value
+        }
+
+    override var unselectedIndicatorColor: Int = 0
+        set(value) {
+            field = value
+            this.unselectedColor = value
+        }
+
+    override fun newInstance(context: Context): View {
+        return this
+    }
+
+    override fun initialize(slideCount: Int) {
+        count = slideCount
+        selectPosition(0)
+        setAnimationType(animationType)
+    }
+
+    override fun selectPosition(index: Int) {
+        selection = index
+    }
+}

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -29,6 +29,9 @@ android {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation project(':appintro')
+    implementation project(':appintro-indicators')
+    implementation "com.romandanylyk:pageindicatorview:1.0.3"
+
     implementation 'androidx.annotation:annotation:1.0.1'
 
     implementation('com.mikepenz:materialdrawer:5.9.1@aar') {

--- a/example/src/main/java/com/amqtech/opensource/appintroexample/ui/mainTabs/intro/DefaultIntro.java
+++ b/example/src/main/java/com/amqtech/opensource/appintroexample/ui/mainTabs/intro/DefaultIntro.java
@@ -7,6 +7,7 @@ import androidx.fragment.app.Fragment;
 
 import com.github.paolorotolo.appintro.AppIntro;
 import com.github.paolorotolo.appintro.AppIntroFragment;
+import com.github.paolorotolo.appintro.indicator.PageIndicatorViewIndicatorController;
 import com.github.paolorotolo.appintro.model.SliderPage;
 import com.github.paolorotolo.appintroexample.R;
 
@@ -47,6 +48,11 @@ public class DefaultIntro extends AppIntro {
         sliderPage4.setImageDrawable(R.drawable.ic_slide4);
         sliderPage4.setBgColor(Color.TRANSPARENT);
         addSlide(AppIntroFragment.newInstance(sliderPage4));
+
+        setIndicatorController(
+                new PageIndicatorViewIndicatorController(this, null,
+                        com.rd.animation.type.AnimationType.WORM)
+        );
     }
 
     @Override

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
-include ':appintro', ':example'
+include ':appintro',
+        ':appintro-indicators',
+        ':example'


### PR DESCRIPTION
This is a Draft PR for #619. I've added a new module `appintro-indicators` that developers can use in order to use a `PageIndicatorView` (and it's animation) as indicator.

Here a sample:
![May-14-2019 13-49-04](https://user-images.githubusercontent.com/3001957/57695735-514cea80-764f-11e9-9f58-637ce3d6438e.gif)

Please note that this is not production ready yet. We probably need to:
* Fix the publishing pipeline (I saw we have a lot of legacy Sonatype publishing config).
* Encapsulate the `AnimationType` enum inside the module (we don't want developers to manually depend on the `pageindicatorview`, the module should work out of the box).

Looking for some early feedback :) @paolorotolo @AnuthaDev 

Fixes #619 