### PR TITLE
Support requesting permissions without locking the Swipe

### DIFF
--- a/appintro/src/main/java/com/github/paolorotolo/appintro/AppIntroViewPager.kt
+++ b/appintro/src/main/java/com/github/paolorotolo/appintro/AppIntroViewPager.kt
@@ -75,6 +75,10 @@ class AppIntroViewPager(context: Context, attrs: AttributeSet) : ViewPager(conte
         return if (LayoutUtil.isRtl(context)) (currentItem - size + 1 == 0) else (currentItem == 0)
     }
 
+    fun getNextItem(size: Int) : Int {
+        return if (LayoutUtil.isRtl(context)) (size - currentItem) else currentItem + 1
+    }
+
     /**
      * Override is required to trigger [OnPageChangeListener.onPageSelected] for the first page.
      * This is needed to correctly handle progress button display after rotation on a locked first page.

--- a/appintro/src/main/java/com/github/paolorotolo/appintro/internal/PermissionWrapper.kt
+++ b/appintro/src/main/java/com/github/paolorotolo/appintro/internal/PermissionWrapper.kt
@@ -1,15 +1,16 @@
 package com.github.paolorotolo.appintro.internal
 
-import java.util.*
-
 /**
  * A data class that represents a set of permissions that should be requested to the user.
  * @property permissions An Array of Permissions from the Android Framework
  * @property position The position in the AppIntro pager when to request those permissions.
+ * @property pending Flag set to true if AppIntro already requested this permission and is awaiting response.
  */
 internal data class PermissionWrapper(
         var permissions: Array<String>,
-        var position: Int) {
+        var position: Int,
+        internal var pending: Boolean = false
+) {
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -17,15 +18,17 @@ internal data class PermissionWrapper(
 
         other as PermissionWrapper
 
-        if (!Arrays.equals(permissions, other.permissions)) return false
+        if (!permissions.contentEquals(other.permissions)) return false
         if (position != other.position) return false
+        if (pending != other.pending) return false
 
         return true
     }
 
     override fun hashCode(): Int {
-        var result = Arrays.hashCode(permissions)
+        var result = permissions.contentHashCode()
         result = 31 * result + position
+        result = 31 * result + pending.hashCode()
         return result
     }
 }


### PR DESCRIPTION
Make sure we don't have to `setSwipeLock(true)` if the user is
requesting a permission. This is achieved by requesting the permission
during the `onPageScrolled`. If the permission is denied, AppIntro will
go to the previous slide.

Example: 
![May-20-2019 23-28-53](https://user-images.githubusercontent.com/3001957/58053196-19fea200-7b57-11e9-969c-0a89bc2b31cd.gif)

Fix #676
Ping @AnuthaDev 