### PR TITLE
Make Travis run all the Gradle tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ android:
     - extra-google-m2repository
 
 script:
-   - ./gradlew clean build lint ktlintCheck detekt test
+   - ./gradlew --continue clean build lint ktlintCheck detekt test


### PR DESCRIPTION
Currently Travis stops the build as soon as it finds a failure. I'd rather let it run all the tasks so we can have the list of KtLint and Detekt failures.