### PR TITLE
Decrease Detekt Max Issues to 1

### DIFF
--- a/appintro/detekt-config.yml
+++ b/appintro/detekt-config.yml
@@ -1,5 +1,5 @@
 build:
-  maxIssues: 10
+  maxIssues: 1
   excludeCorrectable: false
   weights:
     # complexity: 2
@@ -541,7 +541,7 @@ style:
     active: false
   ReturnCount:
     active: true
-    max: 2
+    max: 5
     excludedFunctions: "equals"
     excludeLabeled: false
     excludeReturnFromLambda: true


### PR DESCRIPTION
Looks like that with #726 I accidentally introduced `maxIssues: 10` in the Detekt config. This is causing our build to be green even though we had an error. I'm fixing it here. 