### PR TITLE
Move strings-vi to correct location

### DIFF
--- a/appintro/src/main/res/values-vi/strings.xml
+++ b/appintro/src/main/res/values-vi/strings.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_intro_skip_button">BỎ QUA</string>
     <string name="app_intro_done_button">HOÀN THÀNH</string>
+    <string name="app_intro_skip_button">BỎ QUA</string>
+    <string name="app_intro_next_button">TIẾP TỤC</string>
+    <string name="app_intro_back_button">QUAY LẠI</string>
+    <string name="app_intro_image_content_description">hình ảnh</string>
 </resources>

--- a/library/src/main/res/values-vi/strings.xml
+++ b/library/src/main/res/values-vi/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="app_intro_done_button">HOÀN THÀNH</string>
-    <string name="app_intro_skip_button">BỎ QUA</string>
-    <string name="app_intro_next_button">TIẾP TỤC</string>
-    <string name="app_intro_back_button">QUAY LẠI</string>
-    <string name="app_intro_image_content_description">hình ảnh</string>
-</resources>


### PR DESCRIPTION
Instead of being in the appintro/ directory, the translation was in library/ . This PR fixes it.