### PR TITLE
Fix Visibility leakage before releasing 6.0.0

### DIFF
--- a/appintro/src/main/java/com/github/paolorotolo/appintro/AppIntro.kt
+++ b/appintro/src/main/java/com/github/paolorotolo/appintro/AppIntro.kt
@@ -154,17 +154,6 @@ abstract class AppIntro : AppIntroBase() {
     }
 
     /**
-     * Shows or hides Done button, replaced with setButtonsEnabled();
-     */
-    @Deprecated(
-        "use {@link #setButtonsEnabled(boolean)} instead.",
-        ReplaceWith("setButtonsEnabled = showDone")
-    )
-    fun showDoneButton(showDone: Boolean) {
-        isButtonsEnabled = showDone
-    }
-
-    /**
      * Show or hide the Separator line.
      * This is a static setting and Separator state is maintained across slides
      * until explicitly changed.

--- a/appintro/src/main/java/com/github/paolorotolo/appintro/AppIntro2.kt
+++ b/appintro/src/main/java/com/github/paolorotolo/appintro/AppIntro2.kt
@@ -47,17 +47,6 @@ abstract class AppIntro2 : AppIntroBase() {
     }
 
     /**
-     * Shows or hides Done button, replaced with setButtonsEnabled
-     */
-    @Deprecated(
-        "use {@link #setButtonsEnabled(boolean)} instead.",
-        ReplaceWith("setButtonsEnabled = showDone")
-    )
-    fun showDoneButton(showDone: Boolean) {
-        isButtonsEnabled = showDone
-    }
-
-    /**
      * Override viewpager bar color
      * @param color your color resource
      */

--- a/appintro/src/main/java/com/github/paolorotolo/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/paolorotolo/appintro/AppIntroBase.kt
@@ -28,6 +28,7 @@ import androidx.viewpager.widget.ViewPager
 import com.github.paolorotolo.appintro.indicator.DotIndicatorController
 import com.github.paolorotolo.appintro.indicator.IndicatorController
 import com.github.paolorotolo.appintro.indicator.ProgressIndicatorController
+import com.github.paolorotolo.appintro.internal.AppIntroViewPager
 import com.github.paolorotolo.appintro.internal.LayoutUtil
 import com.github.paolorotolo.appintro.internal.LogHelper
 import com.github.paolorotolo.appintro.internal.PermissionWrapper
@@ -39,7 +40,7 @@ import com.github.paolorotolo.appintro.internal.viewpager.ViewPagerTransformer
  * The AppIntro Base Class. This class is the Activity that is responsible of handling
  * the lifecycle and all the event callbacks for AppIntro.
  */
-abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPager.OnNextPageRequestedListener {
+abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
 
     /** The layout ID that will be used during inflation. */
     @get:LayoutRes
@@ -97,7 +98,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPager.OnNextPageR
      * Toggles vibration on button clicks If you enable it, don't forget to grant
      * vibration permissions on your AndroidManifest.xml file
      * */
-    protected var isVibrateOn = false
+    protected var isVibrate = false
 
     // Private Fields
 
@@ -728,7 +729,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPager.OnNextPageR
     // You must grant vibration permissions on your AndroidManifest.xml file
     @SuppressLint("MissingPermission")
     private fun dispatchVibration() {
-        if (isVibrateOn) {
+        if (isVibrate) {
             vibrator.vibrate(vibrateDuration)
         }
     }
@@ -857,7 +858,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPager.OnNextPageR
         override fun onPageScrollStateChanged(state: Int) {}
     }
 
-    protected companion object {
+    private companion object {
         private val TAG = LogHelper.makeLogTag(AppIntroBase::class.java)
 
         private const val DEFAULT_SCROLL_DURATION_FACTOR = 1

--- a/appintro/src/main/java/com/github/paolorotolo/appintro/AppIntroBaseFragment.kt
+++ b/appintro/src/main/java/com/github/paolorotolo/appintro/AppIntroBaseFragment.kt
@@ -37,7 +37,9 @@ abstract class AppIntroBaseFragment : Fragment(), ISlideSelectionListener, ISlid
 
     private var titleColor: Int = 0
     private var descColor: Int = 0
-    override var defaultBackgroundColor: Int = 0
+    final override var defaultBackgroundColor: Int = 0
+        private set
+
     private var title: String? = null
     private var description: String? = null
     private var titleTypeface: TypefaceContainer? = null

--- a/appintro/src/main/java/com/github/paolorotolo/appintro/AppIntroViewPagerListener.kt
+++ b/appintro/src/main/java/com/github/paolorotolo/appintro/AppIntroViewPagerListener.kt
@@ -1,0 +1,20 @@
+package com.github.paolorotolo.appintro
+
+/**
+ * Register an instance of AppIntroViewPagerListener.
+ * Before the user swipes to the next page, this listener will be called and
+ * can interrupt swiping by returning false to [onCanRequestNextPage]
+ *
+ * [onIllegallyRequestedNextPage] will be called if the user tries to swipe and was not allowed
+ * to do so (useful for showing a toast or something similar).
+ *
+ * [onUserRequestedPermissionsDialog] will be called when the user swipes forward on a slide
+ * that contains permissions.
+ */
+interface AppIntroViewPagerListener {
+    fun onCanRequestNextPage(): Boolean
+
+    fun onIllegallyRequestedNextPage()
+
+    fun onUserRequestedPermissionsDialog()
+}

--- a/appintro/src/main/java/com/github/paolorotolo/appintro/internal/AppIntroViewPager.kt
+++ b/appintro/src/main/java/com/github/paolorotolo/appintro/internal/AppIntroViewPager.kt
@@ -1,12 +1,12 @@
-package com.github.paolorotolo.appintro
+package com.github.paolorotolo.appintro.internal
 
 import android.content.Context
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.animation.Interpolator
 import androidx.viewpager.widget.ViewPager
-import com.github.paolorotolo.appintro.internal.LayoutUtil
-import com.github.paolorotolo.appintro.internal.ScrollerCustomDuration
+import com.github.paolorotolo.appintro.AppIntroBase
+import com.github.paolorotolo.appintro.AppIntroViewPagerListener
 import kotlin.math.absoluteValue
 
 /**
@@ -19,12 +19,12 @@ import kotlin.math.absoluteValue
  * @property onNextPageRequestedListener Listener for Next Page events.
  * @property isNextPagingEnabled Enable or disable swiping to the next page.
  */
-class AppIntroViewPager(context: Context, attrs: AttributeSet) : ViewPager(context, attrs) {
+internal class AppIntroViewPager(context: Context, attrs: AttributeSet) : ViewPager(context, attrs) {
 
     var isFullPagingEnabled = true
     var isPermissionSlide = false
     var lockPage = 0
-    var onNextPageRequestedListener: OnNextPageRequestedListener? = null
+    var onNextPageRequestedListener: AppIntroViewPagerListener? = null
     var isNextPagingEnabled: Boolean = true
         set(value) {
             field = value
@@ -199,26 +199,7 @@ class AppIntroViewPager(context: Context, attrs: AttributeSet) : ViewPager(conte
             (startPoint.y - y).absoluteValue <= VALID_SWIPE_THRESHOLD_PX_Y
         )
 
-    /**
-     * Register an instance of OnNextPageRequestedListener.
-     * Before the user swipes to the next page, this listener will be called and
-     * can interrupt swiping by returning false to [onCanRequestNextPage]
-     *
-     * [onIllegallyRequestedNextPage] will be called if the user tries to swipe and was not allowed
-     * to do so (useful for showing a toast or something similar).
-     *
-     * [onUserRequestedPermissionsDialog] will be called when the user swipes forward on a slide
-     * that contains permissions.
-     */
-    interface OnNextPageRequestedListener {
-        fun onCanRequestNextPage(): Boolean
-
-        fun onIllegallyRequestedNextPage()
-
-        fun onUserRequestedPermissionsDialog()
-    }
-
-    companion object {
+    private companion object {
         private const val ON_ILLEGALLY_REQUESTED_NEXT_PAGE_MAX_INTERVAL = 1000
         private const val VALID_SWIPE_THRESHOLD_PX_X = 25
         private const val VALID_SWIPE_THRESHOLD_PX_Y = 25

--- a/appintro/src/main/java/com/github/paolorotolo/appintro/internal/viewpager/ViewPagerTransformer.kt
+++ b/appintro/src/main/java/com/github/paolorotolo/appintro/internal/viewpager/ViewPagerTransformer.kt
@@ -116,7 +116,7 @@ internal class ViewPagerTransformer(
     }
 }
 
-enum class TransformType {
+internal enum class TransformType {
     FLOW,
     DEPTH,
     ZOOM,

--- a/appintro/src/main/java/com/github/paolorotolo/appintro/model/SliderPage.kt
+++ b/appintro/src/main/java/com/github/paolorotolo/appintro/model/SliderPage.kt
@@ -24,7 +24,6 @@ import com.github.paolorotolo.appintro.ARG_TITLE_TYPEFACE_RES
 data class SliderPage @JvmOverloads constructor(
     var title: CharSequence? = null,
     var description: CharSequence? = null,
-    @DrawableRes var bgDrawable: Int = 0,
     @DrawableRes var imageDrawable: Int = 0,
     @ColorInt var bgColor: Int = 0,
     @ColorInt var titleColor: Int = 0,
@@ -32,7 +31,8 @@ data class SliderPage @JvmOverloads constructor(
     @FontRes var titleTypefaceFontRes: Int = 0,
     @FontRes var descTypefaceFontRes: Int = 0,
     var titleTypeface: String? = null,
-    var descTypeface: String? = null
+    var descTypeface: String? = null,
+    @DrawableRes var bgDrawable: Int = 0
 ) {
     val titleString: String? get() = title?.toString()
     val descriptionString: String? get() = description?.toString()

--- a/appintro/src/main/res/layout/appintro_intro_layout.xml
+++ b/appintro/src/main/res/layout/appintro_intro_layout.xml
@@ -9,7 +9,7 @@
     android:fitsSystemWindows="false"
     android:theme="@style/AppIntroStyle">
 
-    <com.github.paolorotolo.appintro.AppIntroViewPager
+    <com.github.paolorotolo.appintro.internal.AppIntroViewPager
         android:id="@+id/view_pager"
         android:layout_width="0dp"
         android:layout_height="0dp"

--- a/appintro/src/main/res/layout/appintro_intro_layout2.xml
+++ b/appintro/src/main/res/layout/appintro_intro_layout2.xml
@@ -9,7 +9,7 @@
     android:fitsSystemWindows="false"
     android:theme="@style/AppIntroStyle">
 
-    <com.github.paolorotolo.appintro.AppIntroViewPager
+    <com.github.paolorotolo.appintro.internal.AppIntroViewPager
         android:id="@+id/view_pager"
         android:layout_width="0dp"
         android:layout_height="0dp"


### PR DESCRIPTION
I was inspecting the public API of AppIntro and I noticed that we are introducing a lot of breaking changes. Here I'm trying to mitigate some of them:

* Removed all the @Deprecated methods as they're not really needed anymore
* `AppIntroViewPager.OnNextPageRequestedListener` -> `AppIntroViewPagerListener` extracted so we can hide `AppIntroViewPager` inside `.internal`.
* Multiple companion objects were not private, updating them.
* `SliderPage`: moving the new parameter `bgDrawable` as last
