### PR TITLE
Refactor example package name, update gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ In order to provide the translation, your file needs to contain the following st
 An updated version of the english version translation is [available here](appintro/src/main/res/values/strings.xml).
 
 ## Example App
-See example code [here](https://github.com/AppIntro/AppIntro/tree/master/example) on GitHub. You can also see it live by downloading our example on [Google Play](https://play.google.com/store/apps/details?id=com.amqtech.opensource.appintroexample).
+A working example app is available [here](https://github.com/AppIntro/AppIntro/tree/master/example).
 
 ## Real life examples
 Do you need inspiration? A lot of apps are using AppIntro out there:

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.0-rc01'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.4.0"

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "29.0.2"
 
     defaultConfig {
-        applicationId "com.amqtech.opensource.appintroexample"
+        applicationId "com.github.appintro.example.appintroexample"
         minSdkVersion 14
         targetSdkVersion 29
         versionCode 2
@@ -28,8 +28,8 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation project(':appintro')
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.annotation:annotation:1.1.0'
 
     implementation "com.mikepenz:materialdrawer:6.1.2"

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:label="@string/app_name"
         android:theme="@style/CustomTheme"
         android:supportsRtl="true">
-        <activity android:name="com.amqtech.opensource.appintroexample.ui.MainActivity">
+        <activity android:name="com.github.appintro.example.ui.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -22,28 +22,28 @@
         </activity>
 
         <activity
-            android:name="com.amqtech.opensource.appintroexample.ui.mainTabs.intro.DefaultIntro"
+            android:name="com.github.appintro.example.ui.mainTabs.intro.DefaultIntro"
             android:label="@string/app_name"
             android:theme="@style/AppIntroTheme"/>
         <activity
-            android:name="com.amqtech.opensource.appintroexample.ui.mainTabs.intro.DefaultIntro2"
+            android:name="com.github.appintro.example.ui.mainTabs.intro.DefaultIntro2"
             android:label="@string/app_name"
             android:theme="@style/AppIntroTheme"/>
         <activity
-            android:name="com.amqtech.opensource.appintroexample.ui.mainTabs.intro.CustomLayoutIntro"
+            android:name="com.github.appintro.example.ui.mainTabs.intro.CustomLayoutIntro"
             android:label="@string/app_name"
             android:theme="@style/AppIntroTheme"/>
         <activity
-            android:name="com.amqtech.opensource.appintroexample.ui.mainTabs.intro.CustomBackgroundIntro"
+            android:name="com.github.appintro.example.ui.mainTabs.intro.CustomBackgroundIntro"
             android:label="@string/app_name"
             android:theme="@style/AppIntroTheme"/>
 
         <activity
-            android:name="com.amqtech.opensource.appintroexample.ui.permsTabs.intro.PermissionsIntro1"
+            android:name="com.github.appintro.example.ui.permsTabs.intro.PermissionsIntro1"
             android:label="@string/app_name"
             android:theme="@style/AppIntroTheme"/>
         <activity
-            android:name="com.amqtech.opensource.appintroexample.ui.permsTabs.intro.PermissionsIntro2"
+            android:name="com.github.appintro.example.ui.permsTabs.intro.PermissionsIntro2"
             android:label="@string/app_name"
             android:theme="@style/AppIntroTheme"/>
 

--- a/example/src/main/java/com/github/appintro/example/ui/MainActivity.java
+++ b/example/src/main/java/com/github/appintro/example/ui/MainActivity.java
@@ -1,4 +1,4 @@
-package com.amqtech.opensource.appintroexample.ui;
+package com.github.appintro.example.ui;
 
 import android.graphics.Color;
 import android.os.Bundle;
@@ -8,8 +8,8 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import android.view.View;
 
-import com.amqtech.opensource.appintroexample.ui.fragment.MainTabsFragment;
-import com.amqtech.opensource.appintroexample.ui.fragment.PermissionTabsFragment;
+import com.github.appintro.example.ui.fragment.MainTabsFragment;
+import com.github.appintro.example.ui.fragment.PermissionTabsFragment;
 import com.github.paolorotolo.appintroexample.R;
 import com.mikepenz.materialdrawer.Drawer;
 import com.mikepenz.materialdrawer.DrawerBuilder;

--- a/example/src/main/java/com/github/appintro/example/ui/fragment/MainTabsFragment.java
+++ b/example/src/main/java/com/github/appintro/example/ui/fragment/MainTabsFragment.java
@@ -1,4 +1,4 @@
-package com.amqtech.opensource.appintroexample.ui.fragment;
+package com.github.appintro.example.ui.fragment;
 
 import android.graphics.Color;
 import android.os.Bundle;
@@ -9,19 +9,19 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.amqtech.opensource.appintroexample.ui.permsTabs.PermsPagerAdapter;
-import com.amqtech.opensource.appintroexample.util.TabLayout;
+import com.github.appintro.example.ui.mainTabs.MainPagerAdapter;
+import com.github.appintro.example.util.TabLayout;
 import com.github.paolorotolo.appintroexample.R;
 
-public class PermissionTabsFragment extends Fragment {
+public class MainTabsFragment extends Fragment {
 
     ViewPager pager;
-    PermsPagerAdapter adapter;
+    MainPagerAdapter adapter;
     TabLayout tabs;
-    CharSequence Titles[] = {"Layout 1", "Layout 2"};
-    int Numboftabs = 2;
+    CharSequence Titles[] = {"Layout 1", "Layout 2", "Custom Layout", "Custom Background"};
+    int Numboftabs = 4;
 
-    public PermissionTabsFragment() {
+    public MainTabsFragment() {
         //required empty constructor
     }
 
@@ -30,14 +30,14 @@ public class PermissionTabsFragment extends Fragment {
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
-        adapter = new PermsPagerAdapter(getChildFragmentManager(), Titles, Numboftabs);
+        adapter = new MainPagerAdapter(getChildFragmentManager(), Titles, Numboftabs);
 
-        pager = getView().findViewById(R.id.permPager);
+        pager = getView().findViewById(R.id.mainPager);
         pager.setAdapter(adapter);
 
-        tabs = getView().findViewById(R.id.permTabs);
+        tabs = getView().findViewById(R.id.mainTabs);
         tabs.setBackgroundColor(Color.parseColor("#1976D2"));
-        tabs.setDistributeEvenly(true);
+        tabs.setDistributeEvenly(false);
         tabs.setCustomTabColorizer(new TabLayout.TabColorizer() {
             @Override
             public int getIndicatorColor(int position) {
@@ -50,6 +50,6 @@ public class PermissionTabsFragment extends Fragment {
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.fragment_permission_tabs, container, false);
+        return inflater.inflate(R.layout.fragment_main_tabs, container, false);
     }
 }

--- a/example/src/main/java/com/github/appintro/example/ui/fragment/PermissionTabsFragment.java
+++ b/example/src/main/java/com/github/appintro/example/ui/fragment/PermissionTabsFragment.java
@@ -1,4 +1,4 @@
-package com.amqtech.opensource.appintroexample.ui.fragment;
+package com.github.appintro.example.ui.fragment;
 
 import android.graphics.Color;
 import android.os.Bundle;
@@ -9,19 +9,19 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.amqtech.opensource.appintroexample.ui.mainTabs.MainPagerAdapter;
-import com.amqtech.opensource.appintroexample.util.TabLayout;
+import com.github.appintro.example.ui.permsTabs.PermsPagerAdapter;
+import com.github.appintro.example.util.TabLayout;
 import com.github.paolorotolo.appintroexample.R;
 
-public class MainTabsFragment extends Fragment {
+public class PermissionTabsFragment extends Fragment {
 
     ViewPager pager;
-    MainPagerAdapter adapter;
+    PermsPagerAdapter adapter;
     TabLayout tabs;
-    CharSequence Titles[] = {"Layout 1", "Layout 2", "Custom Layout", "Custom Background"};
-    int Numboftabs = 4;
+    CharSequence Titles[] = {"Layout 1", "Layout 2"};
+    int Numboftabs = 2;
 
-    public MainTabsFragment() {
+    public PermissionTabsFragment() {
         //required empty constructor
     }
 
@@ -30,14 +30,14 @@ public class MainTabsFragment extends Fragment {
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
-        adapter = new MainPagerAdapter(getChildFragmentManager(), Titles, Numboftabs);
+        adapter = new PermsPagerAdapter(getChildFragmentManager(), Titles, Numboftabs);
 
-        pager = getView().findViewById(R.id.mainPager);
+        pager = getView().findViewById(R.id.permPager);
         pager.setAdapter(adapter);
 
-        tabs = getView().findViewById(R.id.mainTabs);
+        tabs = getView().findViewById(R.id.permTabs);
         tabs.setBackgroundColor(Color.parseColor("#1976D2"));
-        tabs.setDistributeEvenly(false);
+        tabs.setDistributeEvenly(true);
         tabs.setCustomTabColorizer(new TabLayout.TabColorizer() {
             @Override
             public int getIndicatorColor(int position) {
@@ -50,6 +50,6 @@ public class MainTabsFragment extends Fragment {
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.fragment_main_tabs, container, false);
+        return inflater.inflate(R.layout.fragment_permission_tabs, container, false);
     }
 }

--- a/example/src/main/java/com/github/appintro/example/ui/mainTabs/CustomBackgroundIntro.java
+++ b/example/src/main/java/com/github/appintro/example/ui/mainTabs/CustomBackgroundIntro.java
@@ -1,4 +1,4 @@
-package com.amqtech.opensource.appintroexample.ui.mainTabs;
+package com.github.appintro.example.ui.mainTabs;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -9,21 +9,20 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 
-import com.amqtech.opensource.appintroexample.ui.mainTabs.intro.DefaultIntro2;
 import com.github.paolorotolo.appintroexample.R;
 
-public class DefaultLayout2Intro extends Fragment {
+public class CustomBackgroundIntro extends Fragment {
 
     @SuppressWarnings("ConstantConditions")
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
-        Button demo = getView().findViewById(R.id.intro2);
+        Button demo = getView().findViewById(R.id.intro4);
         demo.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                startActivity(new Intent(getActivity().getBaseContext(), DefaultIntro2.class));
+                startActivity(new Intent(getActivity().getBaseContext(), com.github.appintro.example.ui.mainTabs.intro.CustomBackgroundIntro.class));
             }
         });
     }
@@ -31,6 +30,6 @@ public class DefaultLayout2Intro extends Fragment {
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.tab_default_intro2, container, false);
+        return inflater.inflate(R.layout.tab_custom_background_intro, container, false);
     }
 }

--- a/example/src/main/java/com/github/appintro/example/ui/mainTabs/CustomLayoutIntro.java
+++ b/example/src/main/java/com/github/appintro/example/ui/mainTabs/CustomLayoutIntro.java
@@ -1,4 +1,4 @@
-package com.amqtech.opensource.appintroexample.ui.mainTabs;
+package com.github.appintro.example.ui.mainTabs;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -11,18 +11,18 @@ import android.widget.Button;
 
 import com.github.paolorotolo.appintroexample.R;
 
-public class CustomBackgroundIntro extends Fragment {
+public class CustomLayoutIntro extends Fragment {
 
     @SuppressWarnings("ConstantConditions")
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
-        Button demo = getView().findViewById(R.id.intro4);
+        Button demo = getView().findViewById(R.id.intro3);
         demo.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                startActivity(new Intent(getActivity().getBaseContext(), com.amqtech.opensource.appintroexample.ui.mainTabs.intro.CustomBackgroundIntro.class));
+                startActivity(new Intent(getActivity().getBaseContext(), com.github.appintro.example.ui.mainTabs.intro.CustomLayoutIntro.class));
             }
         });
     }
@@ -30,6 +30,6 @@ public class CustomBackgroundIntro extends Fragment {
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.tab_custom_background_intro, container, false);
+        return inflater.inflate(R.layout.tab_custom_layout_intro, container, false);
     }
 }

--- a/example/src/main/java/com/github/appintro/example/ui/mainTabs/DefaultLayout2Intro.java
+++ b/example/src/main/java/com/github/appintro/example/ui/mainTabs/DefaultLayout2Intro.java
@@ -1,4 +1,4 @@
-package com.amqtech.opensource.appintroexample.ui.mainTabs;
+package com.github.appintro.example.ui.mainTabs;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -9,21 +9,21 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 
-import com.amqtech.opensource.appintroexample.ui.mainTabs.intro.DefaultIntro;
+import com.github.appintro.example.ui.mainTabs.intro.DefaultIntro2;
 import com.github.paolorotolo.appintroexample.R;
 
-public class DefaultLayoutIntro extends Fragment {
+public class DefaultLayout2Intro extends Fragment {
 
     @SuppressWarnings("ConstantConditions")
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
-        Button demo = getView().findViewById(R.id.intro1);
+        Button demo = getView().findViewById(R.id.intro2);
         demo.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                startActivity(new Intent(getActivity().getBaseContext(), DefaultIntro.class));
+                startActivity(new Intent(getActivity().getBaseContext(), DefaultIntro2.class));
             }
         });
     }
@@ -31,6 +31,6 @@ public class DefaultLayoutIntro extends Fragment {
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.tab_default_intro, container, false);
+        return inflater.inflate(R.layout.tab_default_intro2, container, false);
     }
 }

--- a/example/src/main/java/com/github/appintro/example/ui/mainTabs/DefaultLayoutIntro.java
+++ b/example/src/main/java/com/github/appintro/example/ui/mainTabs/DefaultLayoutIntro.java
@@ -1,4 +1,4 @@
-package com.amqtech.opensource.appintroexample.ui.permsTabs;
+package com.github.appintro.example.ui.mainTabs;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -9,10 +9,10 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 
-import com.amqtech.opensource.appintroexample.ui.permsTabs.intro.PermissionsIntro1;
+import com.github.appintro.example.ui.mainTabs.intro.DefaultIntro;
 import com.github.paolorotolo.appintroexample.R;
 
-public class PermissionsLayout1Intro extends Fragment {
+public class DefaultLayoutIntro extends Fragment {
 
     @SuppressWarnings("ConstantConditions")
     @Override
@@ -23,7 +23,7 @@ public class PermissionsLayout1Intro extends Fragment {
         demo.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                startActivity(new Intent(getActivity().getBaseContext(), PermissionsIntro1.class));
+                startActivity(new Intent(getActivity().getBaseContext(), DefaultIntro.class));
             }
         });
     }
@@ -31,6 +31,6 @@ public class PermissionsLayout1Intro extends Fragment {
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.tab_permissions_1, container, false);
+        return inflater.inflate(R.layout.tab_default_intro, container, false);
     }
 }

--- a/example/src/main/java/com/github/appintro/example/ui/mainTabs/MainPagerAdapter.java
+++ b/example/src/main/java/com/github/appintro/example/ui/mainTabs/MainPagerAdapter.java
@@ -1,4 +1,4 @@
-package com.amqtech.opensource.appintroexample.ui.mainTabs;
+package com.github.appintro.example.ui.mainTabs;
 
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;

--- a/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/CustomBackgroundIntro.java
+++ b/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/CustomBackgroundIntro.java
@@ -1,16 +1,17 @@
-package com.amqtech.opensource.appintroexample.ui.mainTabs.intro;
+package com.github.appintro.example.ui.mainTabs.intro;
 
 import android.graphics.Color;
 import android.os.Bundle;
+
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
-import com.github.paolorotolo.appintro.AppIntro;
+import com.github.paolorotolo.appintro.AppIntro2;
 import com.github.paolorotolo.appintro.AppIntroFragment;
 import com.github.paolorotolo.appintro.model.SliderPage;
 import com.github.paolorotolo.appintroexample.R;
 
-public class DefaultIntro extends AppIntro {
+public class CustomBackgroundIntro extends AppIntro2 {
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -18,7 +19,7 @@ public class DefaultIntro extends AppIntro {
 
         SliderPage sliderPage1 = new SliderPage();
         sliderPage1.setTitle("Welcome!");
-        sliderPage1.setDescription("This is a demo of the AppIntro library.");
+        sliderPage1.setDescription("This is a demo of the AppIntro library, with a custom background on each slide!");
         sliderPage1.setImageDrawable(R.drawable.ic_slide1);
         sliderPage1.setBgColor(Color.TRANSPARENT);
         addSlide(AppIntroFragment.newInstance(sliderPage1));
@@ -43,6 +44,9 @@ public class DefaultIntro extends AppIntro {
         sliderPage4.setImageDrawable(R.drawable.ic_slide4);
         sliderPage4.setBgColor(Color.TRANSPARENT);
         addSlide(AppIntroFragment.newInstance(sliderPage4));
+
+        // Bind the background to the intro
+        setBackgroundResource(R.drawable.ic_drawer_header);
     }
 
     @Override

--- a/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/CustomLayoutIntro.java
+++ b/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/CustomLayoutIntro.java
@@ -1,4 +1,4 @@
-package com.amqtech.opensource.appintroexample.ui.mainTabs.intro;
+package com.github.appintro.example.ui.mainTabs.intro;
 
 import android.os.Bundle;
 import androidx.annotation.Nullable;

--- a/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/DefaultIntro.java
+++ b/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/DefaultIntro.java
@@ -1,18 +1,16 @@
-package com.amqtech.opensource.appintroexample.ui.permsTabs.intro;
+package com.github.appintro.example.ui.mainTabs.intro;
 
-import android.Manifest;
 import android.graphics.Color;
 import android.os.Bundle;
-
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
-import com.github.paolorotolo.appintro.AppIntro2;
+import com.github.paolorotolo.appintro.AppIntro;
 import com.github.paolorotolo.appintro.AppIntroFragment;
 import com.github.paolorotolo.appintro.model.SliderPage;
 import com.github.paolorotolo.appintroexample.R;
 
-public class PermissionsIntro2 extends AppIntro2 {
+public class DefaultIntro extends AppIntro {
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -20,14 +18,14 @@ public class PermissionsIntro2 extends AppIntro2 {
 
         SliderPage sliderPage1 = new SliderPage();
         sliderPage1.setTitle("Welcome!");
-        sliderPage1.setDescription("This is a demo of the AppIntro library, with permissions being requested on a slide!");
+        sliderPage1.setDescription("This is a demo of the AppIntro library.");
         sliderPage1.setImageDrawable(R.drawable.ic_slide1);
         sliderPage1.setBgColor(Color.TRANSPARENT);
         addSlide(AppIntroFragment.newInstance(sliderPage1));
 
         SliderPage sliderPage2 = new SliderPage();
-        sliderPage2.setTitle("Permission Request");
-        sliderPage2.setDescription("In order to access your camera, you must give permissions.");
+        sliderPage2.setTitle("Clean App Intros");
+        sliderPage2.setDescription("This library offers developers the ability to add clean app intros at the start of their apps.");
         sliderPage2.setImageDrawable(R.drawable.ic_slide2);
         sliderPage2.setBgColor(Color.TRANSPARENT);
         addSlide(AppIntroFragment.newInstance(sliderPage2));
@@ -45,11 +43,6 @@ public class PermissionsIntro2 extends AppIntro2 {
         sliderPage4.setImageDrawable(R.drawable.ic_slide4);
         sliderPage4.setBgColor(Color.TRANSPARENT);
         addSlide(AppIntroFragment.newInstance(sliderPage4));
-
-        // Here we tell the library to request camera and location permission that are both required.
-        askForPermissions(new String[]{Manifest.permission.CAMERA, Manifest.permission.ACCESS_FINE_LOCATION}, 2, true);
-        // Here we request another permission that is instead not required.
-        askForPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, 3, false);
     }
 
     @Override

--- a/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/DefaultIntro2.java
+++ b/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/DefaultIntro2.java
@@ -1,4 +1,4 @@
-package com.amqtech.opensource.appintroexample.ui.mainTabs.intro;
+package com.github.appintro.example.ui.mainTabs.intro;
 
 import android.os.Bundle;
 

--- a/example/src/main/java/com/github/appintro/example/ui/permsTabs/PermissionsLayout1Intro.java
+++ b/example/src/main/java/com/github/appintro/example/ui/permsTabs/PermissionsLayout1Intro.java
@@ -1,4 +1,4 @@
-package com.amqtech.opensource.appintroexample.ui.mainTabs;
+package com.github.appintro.example.ui.permsTabs;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -9,20 +9,21 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 
+import com.github.appintro.example.ui.permsTabs.intro.PermissionsIntro1;
 import com.github.paolorotolo.appintroexample.R;
 
-public class CustomLayoutIntro extends Fragment {
+public class PermissionsLayout1Intro extends Fragment {
 
     @SuppressWarnings("ConstantConditions")
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
-        Button demo = getView().findViewById(R.id.intro3);
+        Button demo = getView().findViewById(R.id.intro1);
         demo.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                startActivity(new Intent(getActivity().getBaseContext(), com.amqtech.opensource.appintroexample.ui.mainTabs.intro.CustomLayoutIntro.class));
+                startActivity(new Intent(getActivity().getBaseContext(), PermissionsIntro1.class));
             }
         });
     }
@@ -30,6 +31,6 @@ public class CustomLayoutIntro extends Fragment {
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.tab_custom_layout_intro, container, false);
+        return inflater.inflate(R.layout.tab_permissions_1, container, false);
     }
 }

--- a/example/src/main/java/com/github/appintro/example/ui/permsTabs/PermissionsLayout2Intro.java
+++ b/example/src/main/java/com/github/appintro/example/ui/permsTabs/PermissionsLayout2Intro.java
@@ -1,4 +1,4 @@
-package com.amqtech.opensource.appintroexample.ui.permsTabs;
+package com.github.appintro.example.ui.permsTabs;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -9,7 +9,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 
-import com.amqtech.opensource.appintroexample.ui.permsTabs.intro.PermissionsIntro2;
+import com.github.appintro.example.ui.permsTabs.intro.PermissionsIntro2;
 import com.github.paolorotolo.appintroexample.R;
 
 public class PermissionsLayout2Intro extends Fragment {

--- a/example/src/main/java/com/github/appintro/example/ui/permsTabs/PermsPagerAdapter.java
+++ b/example/src/main/java/com/github/appintro/example/ui/permsTabs/PermsPagerAdapter.java
@@ -1,4 +1,4 @@
-package com.amqtech.opensource.appintroexample.ui.permsTabs;
+package com.github.appintro.example.ui.permsTabs;
 
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;

--- a/example/src/main/java/com/github/appintro/example/ui/permsTabs/intro/PermissionsIntro1.java
+++ b/example/src/main/java/com/github/appintro/example/ui/permsTabs/intro/PermissionsIntro1.java
@@ -1,4 +1,4 @@
-package com.amqtech.opensource.appintroexample.ui.permsTabs.intro;
+package com.github.appintro.example.ui.permsTabs.intro;
 
 import android.Manifest;
 import android.graphics.Color;

--- a/example/src/main/java/com/github/appintro/example/ui/permsTabs/intro/PermissionsIntro2.java
+++ b/example/src/main/java/com/github/appintro/example/ui/permsTabs/intro/PermissionsIntro2.java
@@ -1,5 +1,6 @@
-package com.amqtech.opensource.appintroexample.ui.mainTabs.intro;
+package com.github.appintro.example.ui.permsTabs.intro;
 
+import android.Manifest;
 import android.graphics.Color;
 import android.os.Bundle;
 
@@ -11,7 +12,7 @@ import com.github.paolorotolo.appintro.AppIntroFragment;
 import com.github.paolorotolo.appintro.model.SliderPage;
 import com.github.paolorotolo.appintroexample.R;
 
-public class CustomBackgroundIntro extends AppIntro2 {
+public class PermissionsIntro2 extends AppIntro2 {
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -19,14 +20,14 @@ public class CustomBackgroundIntro extends AppIntro2 {
 
         SliderPage sliderPage1 = new SliderPage();
         sliderPage1.setTitle("Welcome!");
-        sliderPage1.setDescription("This is a demo of the AppIntro library, with a custom background on each slide!");
+        sliderPage1.setDescription("This is a demo of the AppIntro library, with permissions being requested on a slide!");
         sliderPage1.setImageDrawable(R.drawable.ic_slide1);
         sliderPage1.setBgColor(Color.TRANSPARENT);
         addSlide(AppIntroFragment.newInstance(sliderPage1));
 
         SliderPage sliderPage2 = new SliderPage();
-        sliderPage2.setTitle("Clean App Intros");
-        sliderPage2.setDescription("This library offers developers the ability to add clean app intros at the start of their apps.");
+        sliderPage2.setTitle("Permission Request");
+        sliderPage2.setDescription("In order to access your camera, you must give permissions.");
         sliderPage2.setImageDrawable(R.drawable.ic_slide2);
         sliderPage2.setBgColor(Color.TRANSPARENT);
         addSlide(AppIntroFragment.newInstance(sliderPage2));
@@ -45,8 +46,10 @@ public class CustomBackgroundIntro extends AppIntro2 {
         sliderPage4.setBgColor(Color.TRANSPARENT);
         addSlide(AppIntroFragment.newInstance(sliderPage4));
 
-        // Bind the background to the intro
-        setBackgroundResource(R.drawable.ic_drawer_header);
+        // Here we tell the library to request camera and location permission that are both required.
+        askForPermissions(new String[]{Manifest.permission.CAMERA, Manifest.permission.ACCESS_FINE_LOCATION}, 2, true);
+        // Here we request another permission that is instead not required.
+        askForPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, 3, false);
     }
 
     @Override

--- a/example/src/main/java/com/github/appintro/example/util/FragmentStatePagerAdapter.java
+++ b/example/src/main/java/com/github/appintro/example/util/FragmentStatePagerAdapter.java
@@ -1,4 +1,4 @@
-package com.amqtech.opensource.appintroexample.util;
+package com.github.appintro.example.util;
 
 import android.app.Fragment;
 import android.app.FragmentManager;

--- a/example/src/main/java/com/github/appintro/example/util/TabLayout.java
+++ b/example/src/main/java/com/github/appintro/example/util/TabLayout.java
@@ -1,4 +1,4 @@
-package com.amqtech.opensource.appintroexample.util;
+package com.github.appintro.example.util;
 
 import android.content.Context;
 import android.graphics.Typeface;

--- a/example/src/main/java/com/github/appintro/example/util/TabStrip.java
+++ b/example/src/main/java/com/github/appintro/example/util/TabStrip.java
@@ -1,4 +1,4 @@
-package com.amqtech.opensource.appintroexample.util;
+package com.github.appintro.example.util;
 
 import android.content.Context;
 import android.graphics.Canvas;

--- a/example/src/main/res/layout-v21/fragment_main_tabs.xml
+++ b/example/src/main/res/layout-v21/fragment_main_tabs.xml
@@ -4,9 +4,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context="com.amqtech.opensource.appintroexample.ui.MainActivity">
+    tools:context="com.github.appintro.example.ui.MainActivity">
 
-    <com.amqtech.opensource.appintroexample.util.TabLayout
+    <com.github.appintro.example.util.TabLayout
         android:id="@+id/mainTabs"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/example/src/main/res/layout-v21/fragment_permission_tabs.xml
+++ b/example/src/main/res/layout-v21/fragment_permission_tabs.xml
@@ -4,9 +4,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context="com.amqtech.opensource.appintroexample.ui.MainActivity">
+    tools:context="com.github.appintro.example.ui.MainActivity">
 
-    <com.amqtech.opensource.appintroexample.util.TabLayout
+    <com.github.appintro.example.util.TabLayout
         android:id="@+id/permTabs"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/example/src/main/res/layout/fragment_main_tabs.xml
+++ b/example/src/main/res/layout/fragment_main_tabs.xml
@@ -4,7 +4,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <com.amqtech.opensource.appintroexample.util.TabLayout
+    <com.github.appintro.example.util.TabLayout
         android:id="@+id/mainTabs"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/example/src/main/res/layout/fragment_permission_tabs.xml
+++ b/example/src/main/res/layout/fragment_permission_tabs.xml
@@ -4,7 +4,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <com.amqtech.opensource.appintroexample.util.TabLayout
+    <com.github.appintro.example.util.TabLayout
         android:id="@+id/permTabs"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/javadoc/overview-frame.html
+++ b/javadoc/overview-frame.html
@@ -18,7 +18,7 @@
         <li><a href="com/github/paolorotolo/appintroexample/package-frame.html"
                target="packageFrame">com.github.paolorotolo.appintroexample</a></li>
         <li><a href="com/github/paolorotolo/appintroexample/util/package-frame.html"
-               target="packageFrame">com.amqtech.opensource.appintroexample.util</a></li>
+               target="packageFrame">com.github.appintro.example.util</a></li>
     </ul>
 </div>
 <p>&nbsp;</p>

--- a/javadoc/overview-summary.html
+++ b/javadoc/overview-summary.html
@@ -87,7 +87,7 @@
         </tr>
         <tr class="altColor">
             <td class="colFirst"><a
-                    href="com/github/paolorotolo/appintroexample/util/package-summary.html">com.amqtech.opensource.appintroexample.util</a>
+                    href="com/github/paolorotolo/appintroexample/util/package-summary.html">com.github.appintro.example.util</a>
             </td>
             <td class="colLast">&nbsp;</td>
         </tr>


### PR DESCRIPTION
Since 6.0.0 is coming out, this PR refactors example app package name to `com.github.appintro.example` since it was before customized by a previous contributor.

After this lands I'll rewrite the examples in Kotlin to improve readability.