### PR TITLE
Remove dependency on kotlin-reflect

### DIFF
--- a/appintro/build.gradle
+++ b/appintro/build.gradle
@@ -25,7 +25,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:2.28.2'


### PR DESCRIPTION
We don't really need `kotlin-reflect`. That's really heavy + we're not using it at all.