### PR TITLE
Remove `I` prefix from interface names

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -88,7 +88,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
     protected var isSystemBackButtonLocked = false
 
     /** Toggles color cross-fading between slides.
-     * Please note that slides should implement [ISlideBackgroundColorHolder] */
+     * Please note that slides should implement [SlideBackgroundColorHolder] */
     protected var isColorTransitionsEnabled = false
 
     /** Vibration duration in milliseconds */
@@ -632,8 +632,8 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
     override fun onCanRequestNextPage(): Boolean {
         val currentFragment = pagerAdapter.getItem(pager.currentItem)
 
-        // Check if the current fragment implements ISlidePolicy, else a change is always allowed.
-        return if (currentFragment is ISlidePolicy && !currentFragment.isPolicyRespected) {
+        // Check if the current fragment implements SlidePolicy, else a change is always allowed.
+        return if (currentFragment is SlidePolicy && !currentFragment.isPolicyRespected) {
             LogHelper.d(TAG, "Slide policy not respected, denying change request.")
             false
         } else {
@@ -644,7 +644,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
 
     override fun onIllegallyRequestedNextPage() {
         val currentFragment = pagerAdapter.getItem(pager.currentItem)
-        if (currentFragment is ISlidePolicy) {
+        if (currentFragment is SlidePolicy) {
             if (!currentFragment.isPolicyRespected) {
                 currentFragment.onUserIllegallyRequestedNextPage()
             }
@@ -752,10 +752,10 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
 
     /** Takes care of calling all the necessary callbacks on Slide Changing. */
     private fun dispatchSlideChangedCallbacks(oldFragment: Fragment?, newFragment: Fragment?) {
-        if (oldFragment is ISlideSelectionListener) {
+        if (oldFragment is SlideSelectionListener) {
             oldFragment.onSlideDeselected()
         }
-        if (newFragment is ISlideSelectionListener) {
+        if (newFragment is SlideSelectionListener) {
             newFragment.onSlideSelected()
         }
         onSlideChanged(oldFragment, newFragment)
@@ -763,8 +763,8 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
 
     /** Performs color interpolation between two slides.. */
     private fun performColorTransition(currentSlide: Fragment?, nextSlide: Fragment?, positionOffset: Float) {
-        if (currentSlide is ISlideBackgroundColorHolder &&
-            nextSlide is ISlideBackgroundColorHolder
+        if (currentSlide is SlideBackgroundColorHolder &&
+            nextSlide is SlideBackgroundColorHolder
         ) {
             // Check if both fragments are attached to an activity,
             // otherwise getDefaultBackgroundColor may fail.
@@ -778,7 +778,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
                 nextSlide.setBackgroundColor(newColor)
             }
         } else {
-            error("Color transitions are only available if all slides implement ISlideBackgroundColorHolder.")
+            error("Color transitions are only available if all slides implement SlideBackgroundColorHolder.")
         }
     }
 

--- a/appintro/src/main/java/com/github/appintro/AppIntroBaseFragment.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBaseFragment.kt
@@ -25,7 +25,7 @@ internal const val ARG_TITLE_COLOR = "title_color"
 internal const val ARG_DESC_COLOR = "desc_color"
 internal const val ARG_BG_DRAWABLE = "bg_drawable"
 
-abstract class AppIntroBaseFragment : Fragment(), ISlideSelectionListener, ISlideBackgroundColorHolder {
+abstract class AppIntroBaseFragment : Fragment(), SlideSelectionListener, SlideBackgroundColorHolder {
 
     private val logTAG = LogHelper.makeLogTag(AppIntroBaseFragment::class.java)
 

--- a/appintro/src/main/java/com/github/appintro/SlideBackgroundColorHolder.kt
+++ b/appintro/src/main/java/com/github/appintro/SlideBackgroundColorHolder.kt
@@ -2,7 +2,7 @@ package com.github.appintro
 
 import androidx.annotation.ColorInt
 
-interface ISlideBackgroundColorHolder {
+interface SlideBackgroundColorHolder {
 
     /**
      * Returns the default background color of the slide

--- a/appintro/src/main/java/com/github/appintro/SlidePolicy.kt
+++ b/appintro/src/main/java/com/github/appintro/SlidePolicy.kt
@@ -1,6 +1,6 @@
 package com.github.appintro
 
-interface ISlidePolicy {
+interface SlidePolicy {
 
     /**
      * Whether the user has fulfilled the slides policy and should be allowed to navigate through the intro further.

--- a/appintro/src/main/java/com/github/appintro/SlideSelectionListener.kt
+++ b/appintro/src/main/java/com/github/appintro/SlideSelectionListener.kt
@@ -1,6 +1,6 @@
 package com.github.appintro
 
-interface ISlideSelectionListener {
+interface SlideSelectionListener {
     /**
      * Called when this slide becomes selected
      */


### PR DESCRIPTION
The `I` prefix is really old-fashined and from the Java days.
Let's clean it up to make the API more Kotlin-friendly.
