### PR TITLE
Fix setIndicatorColor crashing onCreate

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -49,7 +49,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
     /**
      * A subclass of [IndicatorController] to show the progress.
      * If not provided will be initialized with a [DotIndicatorController] */
-    protected lateinit var indicatorController: IndicatorController
+    protected var indicatorController: IndicatorController? = null
 
     /** Toggles all the buttons visibility (between visible and invisible). */
     protected var isButtonsEnabled: Boolean = true
@@ -291,8 +291,8 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         selectedIndicatorColor: Int,
         unselectedIndicatorColor: Int
     ) {
-        indicatorController.selectedIndicatorColor = selectedIndicatorColor
-        indicatorController.unselectedIndicatorColor = unselectedIndicatorColor
+        indicatorController?.selectedIndicatorColor = selectedIndicatorColor
+        indicatorController?.unselectedIndicatorColor = unselectedIndicatorColor
     }
 
     /*
@@ -438,6 +438,9 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
         super.onCreate(savedInstanceState)
 
+        // We default the indicator controller to the Dotted one.
+        indicatorController = DotIndicatorController(this)
+
         // We default to don't show the Status Bar. User can override this.
         showStatusBar(false)
 
@@ -558,13 +561,9 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
     }
 
     private fun initializeIndicator() {
-        if (!::indicatorController.isInitialized) {
-            // Let's default the indicator to the Dotted one.
-            indicatorController = DotIndicatorController(this)
-        }
-        indicatorContainer.addView(indicatorController.newInstance(this))
-        indicatorController.initialize(slidesNumber)
-        indicatorController.selectPosition(currentlySelectedItem)
+        indicatorContainer.addView(indicatorController?.newInstance(this))
+        indicatorController?.initialize(slidesNumber)
+        indicatorController?.selectPosition(currentlySelectedItem)
     }
 
     override fun onKeyDown(code: Int, event: KeyEvent): Boolean {
@@ -826,7 +825,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
 
         override fun onPageSelected(position: Int) {
             if (slidesNumber >= 1) {
-                indicatorController.selectPosition(position)
+                indicatorController?.selectPosition(position)
             }
 
             // Allow the swipe to be re-enabled if a user swipes to a previous slide. Restore

--- a/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/CustomBackgroundIntro.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/CustomBackgroundIntro.kt
@@ -1,5 +1,6 @@
 package com.github.appintro.example.ui.mainTabs.intro
 
+import android.graphics.Color
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import com.github.appintro.AppIntro2
@@ -36,6 +37,9 @@ class CustomBackgroundIntro : AppIntro2() {
 
         // Set intro custom background
         backgroundResource = R.drawable.ic_drawer_header
+
+        // Change the color of the dot indicator.
+        setIndicatorColor(Color.RED, Color.BLACK)
     }
 
     public override fun onSkipPressed(currentFragment: Fragment?) {


### PR DESCRIPTION
Currently the setIndicatorColor is crashing on the onCreate
as the indicator is not yet initialized. I'm fixing the initialization
code for the indicator to appen on the top level class onCreate
