### PR TITLE
Refactor Transformers to use a sealed class

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -33,7 +33,6 @@ import com.github.appintro.internal.LayoutUtil
 import com.github.appintro.internal.LogHelper
 import com.github.appintro.internal.PermissionWrapper
 import com.github.appintro.internal.viewpager.PagerAdapter
-import com.github.appintro.internal.viewpager.TransformType
 import com.github.appintro.internal.viewpager.ViewPagerTransformer
 
 /**
@@ -296,7 +295,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
     }
 
     /*
-     ANIMATIONS
+     TRANSFORMERS
      =================================== */
 
     /**
@@ -308,58 +307,9 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         pager.setScrollDurationFactor(factor.toDouble())
     }
 
-    /** Sets the animation of the intro to a fade animation */
-    protected fun setFadeAnimation() {
-        pager.setPageTransformer(true, ViewPagerTransformer(TransformType.FADE))
-    }
-
-    /**
-     * Sets the animation of the intro to a parallax animation
-     * @param titleParallaxFactor Parallax factor of title
-     * @param imageParallaxFactor Parallax factor of image
-     * @param descriptionParallaxFactor Parallax factor of description
-     */
-    @JvmOverloads
-    protected fun setParallaxAnimation(
-        titleParallaxFactor: Double = 1.0,
-        imageParallaxFactor: Double = -1.0,
-        descriptionParallaxFactor: Double = 2.0
-    ) {
-        val transformer = ViewPagerTransformer(TransformType.PARALLAX).apply {
-            titlePF = titleParallaxFactor
-            imagePF = imageParallaxFactor
-            descriptionPF = descriptionParallaxFactor
-        }
-        pager.setPageTransformer(true, transformer)
-    }
-
-    /** Sets the animation of the intro to a zoom animation */
-    protected fun setZoomAnimation() {
-        pager.setPageTransformer(true, ViewPagerTransformer(TransformType.ZOOM))
-    }
-
-    /** Sets the animation of the intro to a flow animation */
-    protected fun setFlowAnimation() {
-        pager.setPageTransformer(
-            true,
-            ViewPagerTransformer(TransformType.FLOW)
-        )
-    }
-
-    /** Sets the animation of the intro to a slide over animation */
-    protected fun setSlideOverAnimation() {
-        pager.setPageTransformer(
-            true,
-            ViewPagerTransformer(TransformType.SLIDE_OVER)
-        )
-    }
-
-    /** Sets the animation of the intro to a depth animation */
-    protected fun setDepthAnimation() {
-        pager.setPageTransformer(
-            true,
-            ViewPagerTransformer(TransformType.DEPTH)
-        )
+    /** Allows to specify one of the [AppIntroPageTransformerType] for the ViewPager */
+    protected fun setTransformer(appIntroTransformer: AppIntroPageTransformerType) {
+        pager.setAppIntroPageTransformer(appIntroTransformer)
     }
 
     /** Overrides viewpager transformer with you custom [ViewPagerTransformer] */

--- a/appintro/src/main/java/com/github/appintro/AppIntroPageTransformerType.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroPageTransformerType.kt
@@ -1,0 +1,35 @@
+package com.github.appintro
+
+/**
+ * Sealed class to represent all the possible Page Transformers
+ * offered by AppIntro.
+ */
+sealed class AppIntroPageTransformerType {
+
+    /** Sets the animation of the intro to a flow animation */
+    object Flow : AppIntroPageTransformerType()
+
+    /** Sets the animation of the intro to a depth animation */
+    object Depth : AppIntroPageTransformerType()
+
+    /** Sets the animation of the intro to a zoom animation */
+    object Zoom : AppIntroPageTransformerType()
+
+    /** Sets the animation of the intro to a slide over animation */
+    object SlideOver : AppIntroPageTransformerType()
+
+    /** Sets the animation of the intro to a fade animation */
+    object Fade : AppIntroPageTransformerType()
+
+    /**
+     * Sets the animation of the intro to a parallax animation
+     * @property titleParallaxFactor Parallax factor of title
+     * @property imageParallaxFactor Parallax factor of image
+     * @property descriptionParallaxFactor Parallax factor of description
+     */
+    class Parallax(
+            val titleParallaxFactor: Double = 1.0,
+            val imageParallaxFactor: Double = -1.0,
+            val descriptionParallaxFactor: Double = 2.0
+    ) : AppIntroPageTransformerType()
+}

--- a/appintro/src/main/java/com/github/appintro/internal/AppIntroViewPager.kt
+++ b/appintro/src/main/java/com/github/appintro/internal/AppIntroViewPager.kt
@@ -6,7 +6,9 @@ import android.view.MotionEvent
 import android.view.animation.Interpolator
 import androidx.viewpager.widget.ViewPager
 import com.github.appintro.AppIntroBase
+import com.github.appintro.AppIntroPageTransformerType
 import com.github.appintro.AppIntroViewPagerListener
+import com.github.appintro.internal.viewpager.ViewPagerTransformer
 import kotlin.math.absoluteValue
 
 /**
@@ -198,6 +200,10 @@ internal class AppIntroViewPager(context: Context, attrs: AttributeSet) : ViewPa
         (startPoint.x - x).absoluteValue >= VALID_SWIPE_THRESHOLD_PX_X &&
             (startPoint.y - y).absoluteValue <= VALID_SWIPE_THRESHOLD_PX_Y
         )
+
+    fun setAppIntroPageTransformer(appIntroTransformer: AppIntroPageTransformerType) {
+        setPageTransformer(true, ViewPagerTransformer(appIntroTransformer))
+    }
 
     private companion object {
         private const val ON_ILLEGALLY_REQUESTED_NEXT_PAGE_MAX_INTERVAL = 1000

--- a/appintro/src/main/java/com/github/appintro/internal/viewpager/ViewPagerTransformer.kt
+++ b/appintro/src/main/java/com/github/appintro/internal/viewpager/ViewPagerTransformer.kt
@@ -4,6 +4,7 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.viewpager.widget.ViewPager
+import com.github.appintro.AppIntroPageTransformerType
 import com.github.appintro.R
 
 private const val MIN_SCALE_DEPTH = 0.75f
@@ -15,22 +16,28 @@ private const val MIN_ALPHA_SLIDE = 0.35f
 private const val FLOW_ROTATION_ANGLE = -30f
 
 internal class ViewPagerTransformer(
-    private val transformType: TransformType
+    private val transformType: AppIntroPageTransformerType
 ) : ViewPager.PageTransformer {
-    var titlePF: Double = 0.0
-    var imagePF: Double = 0.0
-    var descriptionPF: Double = 0.0
+
+    private var titlePF: Double = 0.0
+    private var imagePF: Double = 0.0
+    private var descriptionPF: Double = 0.0
 
     override fun transformPage(page: View, position: Float) {
         when (transformType) {
-            TransformType.FLOW -> {
+            AppIntroPageTransformerType.Flow -> {
                 page.rotationY = position * FLOW_ROTATION_ANGLE
             }
-            TransformType.SLIDE_OVER -> transformSlideOver(position, page)
-            TransformType.DEPTH -> transformDepth(position, page)
-            TransformType.ZOOM -> transformZoom(position, page)
-            TransformType.FADE -> transformFade(position, page)
-            TransformType.PARALLAX -> transformParallax(position, page)
+            AppIntroPageTransformerType.SlideOver -> transformSlideOver(position, page)
+            AppIntroPageTransformerType.Depth -> transformDepth(position, page)
+            AppIntroPageTransformerType.Zoom -> transformZoom(position, page)
+            AppIntroPageTransformerType.Fade -> transformFade(position, page)
+            is AppIntroPageTransformerType.Parallax -> {
+                titlePF = transformType.titleParallaxFactor
+                imagePF = transformType.imageParallaxFactor
+                descriptionPF = transformType.descriptionParallaxFactor
+                transformParallax(position, page)
+            }
         }
     }
 
@@ -114,15 +121,6 @@ internal class ViewPagerTransformer(
             page.transformDefaults()
         }
     }
-}
-
-internal enum class TransformType {
-    FLOW,
-    DEPTH,
-    ZOOM,
-    SLIDE_OVER,
-    FADE,
-    PARALLAX
 }
 
 private fun View.transformDefaults() {

--- a/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/DefaultIntro2.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/DefaultIntro2.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.fragment.app.Fragment
 import com.github.appintro.AppIntro2
 import com.github.appintro.AppIntroFragment
+import com.github.appintro.AppIntroPageTransformerType
 import com.github.appintro.appintroexample.R
 import com.github.appintro.model.SliderPage
 
@@ -46,7 +47,7 @@ class DefaultIntro2 : AppIntro2() {
                 bgDrawable = R.drawable.back_slide5
         ))
 
-        setParallaxAnimation()
+        setTransformer(AppIntroPageTransformerType.Parallax())
     }
 
     public override fun onSkipPressed(currentFragment: Fragment?) {


### PR DESCRIPTION
I'm cleaning up the API of `AppIntroBase` by removing a lot of methods
used to setup the `PageTransformer`. I'm now exposing only a
`setTransformer` method that accepts an instance of a sealed class.

This allows us to contain a bit the `AppIntroBase` API surface size.