### PR TITLE
Add missing flags for `setStatusBarColor`

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -200,6 +200,8 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
     /** Customize the color of the Status Bar */
     protected fun setStatusBarColor(@ColorInt color: Int) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
+            window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
             window.statusBarColor = color
         }
     }

--- a/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/CustomLayoutIntro.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/CustomLayoutIntro.kt
@@ -15,6 +15,9 @@ class CustomLayoutIntro : AppIntro() {
         addSlide(newInstance(R.layout.intro_custom_layout3))
         addSlide(newInstance(R.layout.intro_custom_layout4))
 
+        showStatusBar(true)
+        setStatusBarColorRes(R.color.accent)
+        setNavBarColorRes(R.color.accent)
         setProgressIndicator()
     }
 


### PR DESCRIPTION
Currently the setStatusBarColor method is not setting the proper
window flags so the color is ignored.
I'm fixing it as well as adding a sample in the sample app.

Also here a screenshot:
![Screenshot_1587837157](https://user-images.githubusercontent.com/3001957/80288076-b6e99800-8735-11ea-85a6-7e98745a32f0.png)
