### PR TITLE
Fix bug on swipe with Permission slide

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -722,7 +722,6 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         } else {
             // Permission is disabled (never ask again is checked)
             // Ask the user to go to settings to enable permission.
-            setSwipeLock(true)
             onUserDisabledPermission(permission)
         }
     }

--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -699,6 +699,8 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         } else {
             // At least one or all of the permissions have been denied.
             deniedPermissions.forEach(::handleDeniedPermission)
+            // Let's force a recenter of the current slide.
+            pager.reCenterCurrentSlide()
         }
     }
 

--- a/appintro/src/main/java/com/github/appintro/internal/AppIntroViewPager.kt
+++ b/appintro/src/main/java/com/github/appintro/internal/AppIntroViewPager.kt
@@ -158,7 +158,6 @@ internal class AppIntroViewPager(context: Context, attrs: AttributeSet) : ViewPa
                 if (isPermissionSlide && isSwipeForward(currentTouchDownX, event.x)) {
                     onNextPageRequestedListener?.onUserRequestedPermissionsDialog()
                 }
-                currentTouchDownX = event.x
             }
         }
         return isFullPagingEnabled

--- a/appintro/src/main/java/com/github/appintro/internal/AppIntroViewPager.kt
+++ b/appintro/src/main/java/com/github/appintro/internal/AppIntroViewPager.kt
@@ -8,6 +8,7 @@ import androidx.viewpager.widget.ViewPager
 import com.github.appintro.AppIntroBase
 import com.github.appintro.AppIntroViewPagerListener
 import kotlin.math.absoluteValue
+import kotlin.math.max
 
 /**
  * Class that controls the [AppIntro] of AppIntro.
@@ -66,6 +67,16 @@ internal class AppIntroViewPager(context: Context, attrs: AttributeSet) : ViewPa
 
     fun goToPreviousSlide() {
         currentItem += if (!LayoutUtil.isRtl(context)) -1 else 1
+    }
+
+    internal fun reCenterCurrentSlide() {
+        // Hacky way to force a recenter of the ViewPager to the current slide.
+        // We perform a page back and forward to recenter the ViewPager at the current position.
+        // This is needed as we're interrupting the user Swipe due to Permissions.
+        // If the user denies a permission, we want to recenter the slide.
+        val item = currentItem
+        setCurrentItem(max(item - 1, 0), false)
+        setCurrentItem(item, false)
     }
 
     fun isFirstSlide(size: Int): Boolean {


### PR DESCRIPTION
Currently the Swiping on Permission slide is bugged.
When swiping backwards and with a permission slides, it could happen
that the carousel is left "frozen" in between two slides. I'm fixing it.

Moreover I'm also unlocking the slide when the user denied a permission.
It should still be possible for a user to eventually go back in
the carousel even if they rejected a permission.

| Before | After |
| -- | -- |
| ![untitled](https://user-images.githubusercontent.com/3001957/80288844-10a09100-873b-11ea-82d9-b27160c88748.gif) | ![untitled2](https://user-images.githubusercontent.com/3001957/80288855-2ada6f00-873b-11ea-8d60-d0d547890685.gif) |

