### PR TITLE
Renamed AppIntroCustomLayoutSlide -> Fragment

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroCustomLayoutFragment.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroCustomLayoutFragment.kt
@@ -8,12 +8,12 @@ import androidx.fragment.app.Fragment
 
 /**
  * Util class to be used when creating a slide with a custom layout.
- * [AppIntroCustomLayoutSlide.newInstance] passing the Layout ID of your custom layout.
+ * [AppIntroCustomLayoutFragment.newInstance] passing the Layout ID of your custom layout.
  *
  * You can then use this Slide with the [AppIntroBase.addSlide] methods to add this slide
  * to your AppIntro.
  */
-class AppIntroCustomLayoutSlide : Fragment() {
+class AppIntroCustomLayoutFragment : Fragment() {
 
     private var layoutResId = 0
 
@@ -31,8 +31,8 @@ class AppIntroCustomLayoutSlide : Fragment() {
     companion object {
         private const val ARG_LAYOUT_RES_ID = "layoutResId"
         @JvmStatic
-        fun newInstance(layoutResId: Int): AppIntroCustomLayoutSlide {
-            val customSlide = AppIntroCustomLayoutSlide()
+        fun newInstance(layoutResId: Int): AppIntroCustomLayoutFragment {
+            val customSlide = AppIntroCustomLayoutFragment()
             val args = Bundle()
             args.putInt(ARG_LAYOUT_RES_ID, layoutResId)
             customSlide.arguments = args

--- a/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/CustomLayoutIntro.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/CustomLayoutIntro.kt
@@ -3,7 +3,7 @@ package com.github.appintro.example.ui.mainTabs.intro
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import com.github.appintro.AppIntro
-import com.github.appintro.AppIntroCustomLayoutSlide.Companion.newInstance
+import com.github.appintro.AppIntroCustomLayoutFragment.Companion.newInstance
 import com.github.appintro.appintroexample.R
 
 class CustomLayoutIntro : AppIntro() {


### PR DESCRIPTION
I'm renaming the newly added class `AppIntroCustomLayoutSlide` to `AppIntroCustomLayoutFragment` to be consistent with the other Fragments we offer.