### PR TITLE
Extend visibility of goToPreviousSlide to protected

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -169,7 +169,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
     }
 
     /** Moves the AppIntro to the previous slide */
-    private fun goToPreviousSlide() {
+    protected fun goToPreviousSlide() {
         pager.goToPreviousSlide()
     }
 


### PR DESCRIPTION
Let's keep the visibility of `goToPreviousSlide` and `goToNextSlide` aligned to `protected`

This comes from the feature request in #795 