### PR TITLE
Fix goToNextSlide default param for RTL

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -174,7 +174,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
     }
 
     /** Moves the AppIntro to the next slide */
-    protected fun goToNextSlide(isLastSlide: Boolean = pager.currentItem + 1 == slidesNumber) {
+    protected fun goToNextSlide(isLastSlide: Boolean = pager.isLastSlide(fragments.size)) {
         if (isLastSlide) {
             onIntroFinished()
         } else {
@@ -524,7 +524,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
             code == KeyEvent.KEYCODE_BUTTON_A ||
             code == KeyEvent.KEYCODE_DPAD_CENTER
         ) {
-            val isLastSlide = pager.currentItem == pagerAdapter.count - 1
+            val isLastSlide = pager.isLastSlide(fragments.size)
             goToNextSlide(isLastSlide)
             if (isLastSlide) {
                 // We emulate the onDonePressed here to keep backward compatibility
@@ -555,9 +555,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
 
     private fun updateButtonsVisibility() {
         if (isButtonsEnabled) {
-            val isLastSlide =
-                !isRtl && pager.currentItem == slidesNumber - 1 ||
-                    isRtl && pager.currentItem == 0
+            val isLastSlide = pager.isLastSlide(fragments.size)
             nextButton.isVisible = !isLastSlide
             doneButton.isVisible = isLastSlide
             skipButton.isVisible = isSkipButtonEnabled && !isLastSlide

--- a/appintro/src/main/java/com/github/appintro/internal/AppIntroViewPager.kt
+++ b/appintro/src/main/java/com/github/appintro/internal/AppIntroViewPager.kt
@@ -85,6 +85,10 @@ internal class AppIntroViewPager(context: Context, attrs: AttributeSet) : ViewPa
         return if (LayoutUtil.isRtl(context)) (currentItem - size + 1 == 0) else (currentItem == 0)
     }
 
+    fun isLastSlide(size: Int): Boolean {
+        return if (LayoutUtil.isRtl(context)) (currentItem == 0) else (currentItem - size + 1 == 0)
+    }
+
     fun getCurrentSlideNumber(size: Int): Int {
         return if (LayoutUtil.isRtl(context)) (size - currentItem) else (currentItem + 1)
     }


### PR DESCRIPTION
Consolidates the way how we check if we are at the last page (both on RTL or LTR). Currently the default parameter for `goToNextSlide` is wrong for RTL (as reported in #800 and won't work correctly.

Moreover we had the same bug in the keyboard management. I'm fixing it.

Fixes #800