### PR TITLE
Fix isButtonsEnabled being reset to true after onCreate

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -121,7 +121,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
     /** HashMap that contains the [PermissionWrapper] objects */
     private var permissionsMap = HashMap<Int, PermissionWrapper>()
 
-    private var retainIsButtonEnabled = true
+    private var retainIsButtonsEnabled = true
 
     // Android SDK
     private lateinit var vibrator: Vibrator
@@ -248,10 +248,10 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         // We retain the button state in order to be able to restore
         // it properly afterwards.
         if (lock) {
-            retainIsButtonEnabled = this.isButtonsEnabled
+            retainIsButtonsEnabled = this.isButtonsEnabled
             this.isButtonsEnabled = true
         } else {
-            this.isButtonsEnabled = retainIsButtonEnabled
+            this.isButtonsEnabled = retainIsButtonsEnabled
         }
         pager.isNextPagingEnabled = !lock
     }
@@ -266,10 +266,10 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         // We retain the button state in order to be able to restore
         // it properly afterwards.
         if (lock) {
-            retainIsButtonEnabled = this.isButtonsEnabled
+            retainIsButtonsEnabled = this.isButtonsEnabled
             this.isButtonsEnabled = true
         } else {
-            this.isButtonsEnabled = retainIsButtonEnabled
+            this.isButtonsEnabled = retainIsButtonsEnabled
         }
         pager.isFullPagingEnabled = !lock
     }
@@ -447,6 +447,9 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         slidesNumber = fragments.size
         initializeIndicator()
 
+        // Makes sure we correctly retain the `isButtonsEnabled` just after onCreate
+        retainIsButtonsEnabled = isButtonsEnabled
+
         // Required for triggering onPageSelected and onSlideChanged for the first page.
         if (isRtl) {
             pager.currentItem = fragments.size - savedCurrentItem
@@ -474,8 +477,8 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         super.onSaveInstanceState(outState)
         outState.apply {
             putInt(ARG_BUNDLE_SLIDES_NUMBER, slidesNumber)
-            putBoolean(ARG_BUNDLE_RETAIN_IS_BUTTON_ENABLED, retainIsButtonEnabled)
-            putBoolean(ARG_BUNDLE_IS_BUTTON_ENABLED, isButtonsEnabled)
+            putBoolean(ARG_BUNDLE_RETAIN_IS_BUTTONS_ENABLED, retainIsButtonsEnabled)
+            putBoolean(ARG_BUNDLE_IS_BUTTONS_ENABLED, isButtonsEnabled)
             putBoolean(ARG_BUNDLE_IS_SKIP_BUTTON_ENABLED, isSkipButtonEnabled)
             putBoolean(ARG_BUNDLE_IS_INDICATOR_ENABLED, isIndicatorEnabled)
 
@@ -494,8 +497,8 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         super.onRestoreInstanceState(savedInstanceState)
         with(savedInstanceState) {
             slidesNumber = getInt(ARG_BUNDLE_SLIDES_NUMBER)
-            retainIsButtonEnabled = getBoolean(ARG_BUNDLE_RETAIN_IS_BUTTON_ENABLED)
-            isButtonsEnabled = getBoolean(ARG_BUNDLE_IS_BUTTON_ENABLED)
+            retainIsButtonsEnabled = getBoolean(ARG_BUNDLE_RETAIN_IS_BUTTONS_ENABLED)
+            isButtonsEnabled = getBoolean(ARG_BUNDLE_IS_BUTTONS_ENABLED)
             isSkipButtonEnabled = getBoolean(ARG_BUNDLE_IS_SKIP_BUTTON_ENABLED)
             isIndicatorEnabled = getBoolean(ARG_BUNDLE_IS_INDICATOR_ENABLED)
 
@@ -783,7 +786,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
             // state of progress button depending on global progress button setting
             if (!pager.isNextPagingEnabled) {
                 if (pager.currentItem != pager.lockPage) {
-                    isButtonsEnabled = retainIsButtonEnabled
+                    isButtonsEnabled = retainIsButtonsEnabled
                     pager.isNextPagingEnabled = true
                 }
             }
@@ -818,14 +821,14 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
 
         private const val ARG_BUNDLE_COLOR_TRANSITIONS_ENABLED = "colorTransitionEnabled"
         private const val ARG_BUNDLE_CURRENT_ITEM = "currentItem"
-        private const val ARG_BUNDLE_IS_BUTTON_ENABLED = "isButtonsEnabled"
+        private const val ARG_BUNDLE_IS_BUTTONS_ENABLED = "isButtonsEnabled"
         private const val ARG_BUNDLE_IS_FULL_PAGING_ENABLED = "isFullPagingEnabled"
         private const val ARG_BUNDLE_IS_INDICATOR_ENABLED = "isIndicatorEnabled"
         private const val ARG_BUNDLE_IS_NEXT_PAGING_ENABLED = "isNextPagingEnabled"
         private const val ARG_BUNDLE_IS_SKIP_BUTTON_ENABLED = "isSkipButtonsEnabled"
         private const val ARG_BUNDLE_LOCK_PAGE = "lockPage"
         private const val ARG_BUNDLE_PERMISSION_MAP = "permissionMap"
-        private const val ARG_BUNDLE_RETAIN_IS_BUTTON_ENABLED = "retainIsButtonEnabled"
+        private const val ARG_BUNDLE_RETAIN_IS_BUTTONS_ENABLED = "retainIsButtonsEnabled"
         private const val ARG_BUNDLE_SLIDES_NUMBER = "slidesNumber"
     }
 }


### PR DESCRIPTION
Currently we initialize `retainIsButtonsEnabled = true`. This overrides the value specified by the user in the onCreate, specifically if it's false. I'm fixing it with a proper initialisation after the onCreate.

Fixes #804 