### PR TITLE
Basic Androidx navigation component support

### DIFF
--- a/appintro/build.gradle
+++ b/appintro/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'io.gitlab.arturbosch.detekt'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
+apply plugin: "androidx.navigation.safeargs"
 
 group = 'com.github.AppIntro'
 
@@ -29,6 +30,8 @@ dependencies {
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:2.28.2'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.navigation:navigation-fragment:2.3.0-beta01'
+    implementation 'androidx.navigation:navigation-ui:2.3.0-beta01'
 }
 
 repositories {

--- a/appintro/src/main/res/layout/appintro_intro_layout.xml
+++ b/appintro/src/main/res/layout/appintro_intro_layout.xml
@@ -9,6 +9,25 @@
     android:fitsSystemWindows="false"
     android:theme="@style/AppIntroStyle">
 
+    <fragment
+        android:id="@+id/nav_appintro_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:defaultNavHost="false"
+        app:layout_constraintBottom_toTopOf="@+id/guideline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/appintro_navigation" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.5" />
+
     <com.github.appintro.internal.AppIntroViewPager
         android:id="@+id/view_pager"
         android:layout_width="0dp"
@@ -18,7 +37,9 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/nav_appintro_fragment">
+
+    </com.github.appintro.internal.AppIntroViewPager>
 
     <View
         android:id="@+id/bottom_separator"

--- a/appintro/src/main/res/layout/appintro_intro_layout2.xml
+++ b/appintro/src/main/res/layout/appintro_intro_layout2.xml
@@ -9,6 +9,25 @@
     android:fitsSystemWindows="false"
     android:theme="@style/AppIntroStyle">
 
+    <fragment
+        android:id="@+id/nav_appintro_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:defaultNavHost="true"
+        app:layout_constraintBottom_toTopOf="@+id/guideline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/appintro_navigation" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.5" />
+
     <com.github.appintro.internal.AppIntroViewPager
         android:id="@+id/view_pager"
         android:layout_width="0dp"
@@ -18,7 +37,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="@+id/guideline" />
 
     <View
         android:id="@+id/bottom"

--- a/appintro/src/main/res/navigation/appintro_navigation.xml
+++ b/appintro/src/main/res/navigation/appintro_navigation.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/appintro_navigation"
+    app:startDestination="@+id/nav_appintro_fragment">
+
+    <fragment
+        android:id="@+id/nav_appintro_fragment"
+        android:name="com.github.appintro.AppIntroFragment">
+    </fragment>
+</navigation>

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.7.4"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:9.2.1"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.0-beta01"
     }
 }
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: "androidx.navigation.safeargs"
 
 android {
     compileSdkVersion 29
@@ -37,6 +38,8 @@ dependencies {
     implementation "com.mikepenz:materialdrawer:6.1.2"
     implementation "androidx.core:core-ktx:1.2.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'androidx.navigation:navigation-fragment:2.3.0-beta01'
+    implementation 'androidx.navigation:navigation-ui:2.3.0-beta01'
 }
 repositories {
     mavenCentral()

--- a/example/src/main/java/com/github/appintro/example/ui/fragment/TestFragment.java
+++ b/example/src/main/java/com/github/appintro/example/ui/fragment/TestFragment.java
@@ -1,0 +1,24 @@
+package com.github.appintro.example.ui.fragment;
+
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.github.appintro.appintroexample.R;
+
+public class TestFragment extends Fragment {
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable final ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.test_fragment, container, false);
+
+        Log.d("TestFragment", "Successful loaded");
+
+        return view;
+    }
+}

--- a/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/CustomLayoutIntro.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/CustomLayoutIntro.kt
@@ -2,14 +2,19 @@ package com.github.appintro.example.ui.mainTabs.intro
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment
+import androidx.navigation.Navigation
 import com.github.appintro.AppIntro
 import com.github.appintro.AppIntroCustomLayoutFragment.Companion.newInstance
 import com.github.appintro.appintroexample.R
+
 
 class CustomLayoutIntro : AppIntro() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        Navigation.findNavController(this, R.id.nav_appintro_fragment).setGraph(R.navigation.slide_navigation)
+
+        addSlide(IntroCustomLayout1.newInstance(R.layout.intro_custom_layout1));
         addSlide(newInstance(R.layout.intro_custom_layout1))
         addSlide(newInstance(R.layout.intro_custom_layout2))
         addSlide(newInstance(R.layout.intro_custom_layout3))

--- a/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/IntroCustomLayout1.java
+++ b/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/IntroCustomLayout1.java
@@ -1,0 +1,57 @@
+package com.github.appintro.example.ui.mainTabs.intro;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.navigation.Navigation;
+
+import com.github.appintro.appintroexample.R;
+
+public class IntroCustomLayout1 extends Fragment {
+
+    private static final String ARG_LAYOUT_RES_ID = "layoutResId";
+    private int layoutResId;
+
+    public static IntroCustomLayout1 newInstance(int layoutResId) {
+        IntroCustomLayout1 sampleSlide = new IntroCustomLayout1();
+
+        Bundle args = new Bundle();
+        args.putInt(ARG_LAYOUT_RES_ID, layoutResId);
+        sampleSlide.setArguments(args);
+
+        return sampleSlide;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (getArguments() != null && getArguments().containsKey(ARG_LAYOUT_RES_ID)) {
+            layoutResId = getArguments().getInt(ARG_LAYOUT_RES_ID);
+        }
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable final ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        View view = inflater.inflate(layoutResId, container, false);
+
+        Button button = view.findViewById(R.id.button);
+
+        button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Navigation.findNavController(getActivity(), R.id.nav_appintro_fragment).navigate(R.id.testFragment);
+            }
+        });
+
+
+        return view;
+    }
+}

--- a/example/src/main/java/com/github/appintro/example/ui/permsTabs/PermissionsLayout2Intro.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/permsTabs/PermissionsLayout2Intro.kt
@@ -15,7 +15,7 @@ class PermissionsLayout2Intro : Fragment() {
         super.onActivityCreated(savedInstanceState)
 
         intro2.setOnClickListener {
-            startActivity(Intent(activity!!.baseContext, PermissionsIntro2::class.java))
+            startActivity(Intent(requireActivity().baseContext, PermissionsIntro2::class.java))
         }
     }
 

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -1,4 +1,5 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:gravity="center"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -14,4 +15,15 @@
         android:id="@+id/frame_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
+
+    <fragment
+        android:id="@+id/nav_slide_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:defaultNavHost="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/slide_navigation" />
 </RelativeLayout>

--- a/example/src/main/res/layout/intro_custom_layout1.xml
+++ b/example/src/main/res/layout/intro_custom_layout1.xml
@@ -13,6 +13,7 @@
         android:textColor="#ffffff" />
 
     <Button
+        android:id="@+id/button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Button 1" />

--- a/example/src/main/res/layout/test_fragment.xml
+++ b/example/src/main/res/layout/test_fragment.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Hello World!"
+        android:textColor="@color/ic_launcher_background"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/example/src/main/res/navigation/slide_navigation.xml
+++ b/example/src/main/res/navigation/slide_navigation.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/appintro_navigation"
+    app:startDestination="@+id/nav_appintro_fragment">
+
+    <fragment
+        android:id="@+id/nav_appintro_fragment"
+        android:name="com.github.appintro.AppIntroFragment">
+    </fragment>
+    <fragment
+        android:id="@+id/testFragment"
+        android:name="com.github.appintro.example.ui.fragment.TestFragment"
+        android:label="TestFragment" />
+    <fragment
+        android:id="@+id/introCustomLayout1"
+        android:name="com.github.appintro.example.ui.mainTabs.intro.IntroCustomLayout1"
+        android:label="IntroCustomLayout1" >
+        <action
+            android:id="@+id/action_introCustomLayout1_to_testFragment"
+            app:destination="@id/testFragment" />
+    </fragment>
+</navigation>


### PR DESCRIPTION
regarding to issue #801 I implemented a basic support for the new Androidx navigation component, so that an app can set a navigation graph and navigate to another fragment (outside of the AppIntro activity)

This PR is **not** merge ready!

This should show only the basic principle for an navigation sample.

What still have to be done is the following:

- Separate AppIntro class into a AppNav class and a AppInto fragment. The AppNav class should only contain the general layout (like toolbar and so on). The AppIntro fragment should contain the ViewPager. This fragment could be the default fragment which is shown into the NavFragment.
(Currently in this PR for a simplification I divide the screen one half for the NavFragment and the lower part for the ViewPager)

- Convert the current Java classes into Kotlin (Sorry I never used Kotlin before, so I programmed in Java)

- Currently, I didn't found a solution that the SafeArgs method works but you could pass Arguments with the Bundle method to another Fragment

If you have any question, please feel free to ask me. I will try to answer them.