### PR TITLE
Fix bug with SetSwipeLock being reset to false

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -689,19 +689,11 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
     }
 
     /**
-     * Called by [ViewPager.OnPageChangeListener.onPageSelected] to tell [AppIntroViewPager]
-     * to request permissions on swipe.
-     * This method notifies [AppIntroViewPager] that the currently selected slide
+     * Getter used to notify [AppIntroViewPager] if the currently selected slide
      * has permissions attached to it.
      */
-    private fun setPermissionSlide() {
-        if (pager.getCurrentSlideNumber(fragments.size) in permissionsMap) {
-            pager.isPermissionSlide = true
-        } else {
-            pager.isPermissionSlide = false
-            setSwipeLock(false)
-        }
-    }
+    private val isPermissionSlide : Boolean
+        get() = pager.getCurrentSlideNumber(fragments.size) in permissionsMap
 
     /** Takes care of calling all the necessary callbacks on Slide Changing. */
     private fun dispatchSlideChangedCallbacks(oldFragment: Fragment?, newFragment: Fragment?) {
@@ -792,7 +784,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
             }
             updateButtonsVisibility()
 
-            setPermissionSlide()
+            pager.isPermissionSlide = this@AppIntroBase.isPermissionSlide
 
             // Firing all the necessary Callbacks
             this@AppIntroBase.onPageSelected(position)

--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -692,7 +692,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
      * Getter used to notify [AppIntroViewPager] if the currently selected slide
      * has permissions attached to it.
      */
-    private val isPermissionSlide : Boolean
+    private val isPermissionSlide: Boolean
         get() = pager.getCurrentSlideNumber(fragments.size) in permissionsMap
 
     /** Takes care of calling all the necessary callbacks on Slide Changing. */


### PR DESCRIPTION
We used to have some `setSwipeLock(false)` from the early days where we locked swipe during permission. This was still lurking around.

I've also renamed the method to be cleaner and don't have further side effects.

Fixes #819