### PR TITLE
Add a sample with SlidePolicy to the example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,8 @@ class MyFragment : Fragment(), SlidePolicy {
 }
 ```
 
+You can find a full working example of `SlidePolicy` in the [example app - CustomSlidePolicyFragment.kt](example/src/main/java/com/github/appintro/example/ui/custom/fragments/CustomSlidePolicyFragment.kt)
+
 ## Example App 💡
 
 AppIntro comes with a **sample app** full of examples and use case that you can use as inspiration for your project. You can find it inside the [/example folder](https://github.com/AppIntro/AppIntro/tree/master/example).

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -37,7 +37,10 @@
             android:name=".ui.custom.CustomBackgroundIntro"
             android:label="@string/app_name"
             android:theme="@style/AppIntroTheme"/>
-
+        <activity
+            android:name=".ui.custom.SlidePolicyIntro"
+            android:label="@string/app_name"
+            android:theme="@style/AppIntroTheme"/>
         <activity
             android:name=".ui.permissions.PermissionsIntro"
             android:label="@string/app_name"

--- a/example/src/main/java/com/github/appintro/example/ui/IntroEntry.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/IntroEntry.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StringRes
 import com.github.appintro.example.R
 import com.github.appintro.example.ui.custom.CustomBackgroundIntro
 import com.github.appintro.example.ui.custom.CustomLayoutIntro
+import com.github.appintro.example.ui.custom.SlidePolicyIntro
 import com.github.appintro.example.ui.default.DefaultIntro
 import com.github.appintro.example.ui.default.DefaultIntro2
 import com.github.appintro.example.ui.permissions.PermissionsIntro
@@ -20,6 +21,7 @@ val defaultEntries = listOf(
         IntroEntry(R.string.default_intro2_title, R.string.default_intro2, DefaultIntro2::class.java),
         IntroEntry(R.string.custom_layout_intro_title, R.string.custom_layout_intro, CustomLayoutIntro::class.java),
         IntroEntry(R.string.custom_background_intro_title, R.string.custom_background_intro, CustomBackgroundIntro::class.java),
+        IntroEntry(R.string.slide_policy_intro_title, R.string.slide_policy_intro, SlidePolicyIntro::class.java),
         IntroEntry(R.string.perms_intro1_title, R.string.perms_intro1, PermissionsIntro::class.java),
         IntroEntry(R.string.perms_intro2_title, R.string.perms_intro2, PermissionsIntro2::class.java)
 )

--- a/example/src/main/java/com/github/appintro/example/ui/custom/SlidePolicyIntro.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/custom/SlidePolicyIntro.kt
@@ -1,0 +1,35 @@
+package com.github.appintro.example.ui.custom
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import com.github.appintro.AppIntro
+import com.github.appintro.AppIntroFragment
+import com.github.appintro.example.ui.custom.fragments.CustomSlidePolicyFragment
+
+class SlidePolicyIntro : AppIntro() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        addSlide(AppIntroFragment.newInstance(
+                "Welcome",
+                "This is a demo of the AppIntro library, using the SlidePolicy feature."
+        ))
+
+        addSlide(CustomSlidePolicyFragment.newInstance())
+
+        addSlide(AppIntroFragment.newInstance(
+                "Policy Respected!",
+                "If the user arrived here, the SlidePolicy was respected."
+        ))
+    }
+
+    public override fun onSkipPressed(currentFragment: Fragment?) {
+        super.onSkipPressed(currentFragment)
+        finish()
+    }
+
+    public override fun onDonePressed(currentFragment: Fragment?) {
+        super.onDonePressed(currentFragment)
+        finish()
+    }
+}

--- a/example/src/main/java/com/github/appintro/example/ui/custom/fragments/CustomSlidePolicyFragment.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/custom/fragments/CustomSlidePolicyFragment.kt
@@ -1,0 +1,44 @@
+package com.github.appintro.example.ui.custom.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.CheckBox
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import com.github.appintro.SlidePolicy
+import com.github.appintro.example.R
+
+class CustomSlidePolicyFragment : Fragment(), SlidePolicy {
+
+    private lateinit var checkBox: CheckBox
+
+    override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+    ): View? = inflater.inflate(R.layout.intro_slide_policy, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        checkBox = view.findViewById(R.id.check_box)
+    }
+
+    override val isPolicyRespected: Boolean
+        get() = checkBox.isChecked
+
+    override fun onUserIllegallyRequestedNextPage() {
+        Toast.makeText(
+                requireContext(),
+                R.string.please_select_the_checkbox_before_proceeding,
+                Toast.LENGTH_SHORT
+        ).show()
+    }
+
+    companion object {
+        fun newInstance() : CustomSlidePolicyFragment {
+            return CustomSlidePolicyFragment()
+        }
+    }
+}

--- a/example/src/main/res/layout/intro_slide_policy.xml
+++ b/example/src/main/res/layout/intro_slide_policy.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        style="@style/AppIntroDefaultHeading"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_margin="16dp"
+        android:text="@string/slidepolicy_example_heading" />
+
+    <TextView
+        style="@style/AppIntroDefaultText"
+        android:layout_margin="16dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/slidepolicy_example_description" />
+
+    <CheckBox
+        style="@style/AppIntroDefaultText"
+        android:layout_margin="16dp"
+        android:id="@+id/check_box"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:checked="false"
+        android:text="@string/please_check_to_continue" />
+
+</LinearLayout>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="default_intro2_title">Default Intro 2</string>
     <string name="custom_layout_intro_title">Custom Layout Intro</string>
     <string name="custom_background_intro_title">Custom Background Intro</string>
+    <string name="slide_policy_intro_title">Slide Policy Intro</string>
     <string name="perms_intro1_title">Permissions Intro</string>
     <string name="perms_intro2_title">Permissions Intro 2</string>
 
@@ -18,9 +19,16 @@
     <string name="default_intro2">This is the second layout provided by AppIntro library, with icons instead of text</string>
     <string name="custom_layout_intro">This demonstrates the ability to pass a custom layout to the library for added customization.</string>
     <string name="custom_background_intro">This demonstrates the ability to set custom backgrounds for different slides. Useful if you want images vs. colors in your backgrounds.</string>
+    <string name="slide_policy_intro">This demonstrates the SlidePolicy feature, with the possibility to block a user during a Intro.</string>
 
     <!-- 2nd Tab Group -->
     <string name="perms_intro1">This demonstrates the ability to request runtime permission on any desired slide.</string>
     <string name="perms_intro2">This demonstrates the ability to request permission on any slide specified using the second slide layout.</string>
+
+    <!-- SlidePolicy Example -->
+    <string name="please_select_the_checkbox_before_proceeding">Please select the Checkbox before proceeding</string>
+    <string name="slidepolicy_example_heading">SlidePolicy Example</string>
+    <string name="slidepolicy_example_description">This slide won\'t allow the user to proceed till you click the following checkbox</string>
+    <string name="please_check_to_continue">Please check to continue</string>
 
 </resources>


### PR DESCRIPTION
I'm adding a sample to the sample app with `SlidePolicy`. 
This helps us to clarify the #841 issue and provides a simple copy-n-paste solution for a `SlidePolicy` that we can point to our users.

Here a video of the sample:
![untitled](https://user-images.githubusercontent.com/3001957/90595957-3e2faf80-e1ee-11ea-8ffc-8ce3702d35d7.gif)
