### PR TITLE
Changing Visibility of Progress Bar when count of silde is one

### DIFF
--- a/appintro/src/main/java/com/github/appintro/indicator/ProgressIndicatorController.kt
+++ b/appintro/src/main/java/com/github/appintro/indicator/ProgressIndicatorController.kt
@@ -3,6 +3,7 @@ package com.github.appintro.indicator
 import android.content.Context
 import android.graphics.PorterDuff
 import android.util.AttributeSet
+import android.view.View
 import android.widget.ProgressBar
 
 internal const val DEFAULT_COLOR = 1
@@ -35,6 +36,9 @@ class ProgressIndicatorController @JvmOverloads constructor(
 
     override fun initialize(slideCount: Int) {
         this.max = slideCount
+        if (max == 1) {
+            this.visibility = View.INVISIBLE
+        }
         selectPosition(0)
     }
 

--- a/appintro/src/main/java/com/github/appintro/indicator/ProgressIndicatorController.kt
+++ b/appintro/src/main/java/com/github/appintro/indicator/ProgressIndicatorController.kt
@@ -36,7 +36,7 @@ class ProgressIndicatorController @JvmOverloads constructor(
 
     override fun initialize(slideCount: Int) {
         this.max = slideCount
-        if (max == 1) {
+        if (slideCount == 1) {
             this.visibility = View.INVISIBLE
         }
         selectPosition(0)


### PR DESCRIPTION
Bug :
The Progress bar indicator is shown even when there is only one slide.
<img src="https://user-images.githubusercontent.com/50791485/96756016-10830480-13f1-11eb-97f1-e73cdccd0ba7.png"
width=200 height=100/>

Adding invisible condition for the Single Slide Progress Indicator similar to #504 and resolved similar to in a similar way #876