### PR TITLE
Do not show back arrow on wizard mode on first slide

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -559,10 +559,11 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
     private fun updateButtonsVisibility() {
         if (isButtonsEnabled) {
             val isLastSlide = pager.isLastSlide(fragments.size)
+            val isFirstSlide = pager.isFirstSlide(fragments.size)
             nextButton.isVisible = !isLastSlide
             doneButton.isVisible = isLastSlide
             skipButton.isVisible = isSkipButtonEnabled && !isLastSlide
-            backButton.isVisible = isWizardMode
+            backButton.isVisible = isWizardMode && !isFirstSlide
         } else {
             nextButton.isVisible = false
             doneButton.isVisible = false


### PR DESCRIPTION
When on Wizard mode, the first slide is showing the back arrow. This should not happen.

Fixes #889 