### PR TITLE
Run Pre merge checks only on master

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -2,7 +2,7 @@ name: Pre Merge Checks
 on:
   push:
     branches:
-      - '*'
+      - 'master'
   pull_request:
     branches:
       - '*'


### PR DESCRIPTION
I've set up two shadow CI jobs to test how Kotlin EAP and AGP alpha behaves with our library:
https://github.com/AppIntro/AppIntro/commit/817a633771733196dc376cfa451c2c778d1babd1

Here I'm cleaning up the job to make sure that we run only on master and not on all the branches.