### PR TITLE
Fix for crash on PagerAdapter when using SlidePolicy

### DIFF
--- a/appintro/src/main/java/com/github/appintro/internal/viewpager/PagerAdapter.kt
+++ b/appintro/src/main/java/com/github/appintro/internal/viewpager/PagerAdapter.kt
@@ -1,16 +1,23 @@
 package com.github.appintro.internal.viewpager
 
+import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
 
 internal class PagerAdapter(
     fragmentManager: FragmentManager,
-    private val fragments: List<Fragment>
+    private val fragments: MutableList<Fragment>
 ) : FragmentPagerAdapter(fragmentManager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
 
     override fun getItem(position: Int): Fragment {
         return fragments[position]
+    }
+
+    override fun instantiateItem(container: ViewGroup, position: Int): Any {
+        val frament = super.instantiateItem(container, position)
+        fragments[position] = (frament as Fragment)
+        return frament
     }
 
     override fun getCount() = this.fragments.size


### PR DESCRIPTION
This fixes a crash that arise when orientation changes are happening on a `SlidePolicy` Fragment.
Steps to reproduce the crash are available in the description of #893 

Fixes #893 
