### PR TITLE
Added app using AppIntro

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,5 +579,6 @@ If you are using AppIntro in your app and would like to be listed here, please o
 * [Shopping list](https://play.google.com/store/apps/details?id=de.vanse.shoppinglist) and [Shopping list pro](https://play.google.com/store/apps/details?id=de.vanse.shoppinglist.pro)
 * [PZPIC - Pan & Zoom Effect Video from Still Picture](https://play.google.com/store/apps/details?id=com.photo3dlab.pzpic)
 * [PrezziBenzina](https://play.google.com/store/apps/details?id=org.vernazza.androidfuel&hl=it)
+* [LogViewer for openHAB](https://github.com/cyb3rko/logviewer-for-openhab-app)
 
 </details>


### PR DESCRIPTION
My reworked version of the LogViewer for openHAB app for Android is now using AppIntro as well!

Here are some of the slides:

<img src="https://user-images.githubusercontent.com/46033730/98288354-05120a80-1fa7-11eb-8844-6c5689cb0965.jpg" width="300">
<img src="https://user-images.githubusercontent.com/46033730/98288357-06433780-1fa7-11eb-8420-19ae6796bf86.jpg" width="300">
<img src="https://user-images.githubusercontent.com/46033730/98288359-07746480-1fa7-11eb-90c1-39a4d244a460.jpg" width="300">
