### PR TITLE
ISlidePolicy Example

### DIFF
--- a/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/CustomLayoutIntro.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/CustomLayoutIntro.kt
@@ -10,6 +10,7 @@ class CustomLayoutIntro : AppIntro() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        addSlide(PrivacyPolicyFragment.newInstance())
         addSlide(newInstance(R.layout.intro_custom_layout1))
         addSlide(newInstance(R.layout.intro_custom_layout2))
         addSlide(newInstance(R.layout.intro_custom_layout3))

--- a/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/PrivacyPolicyFragment.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/mainTabs/intro/PrivacyPolicyFragment.kt
@@ -1,0 +1,39 @@
+package com.github.appintro.example.ui.mainTabs.intro
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.CheckBox
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import com.github.appintro.ISlidePolicy
+import com.github.appintro.appintroexample.R
+
+class PrivacyPolicyFragment : Fragment(), ISlidePolicy {
+
+    lateinit var checkBox: CheckBox
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_checkbox, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        checkBox = view.findViewById(R.id.checkbox)
+    }
+
+    override val isPolicyRespected: Boolean
+        get() = checkBox.isChecked
+
+    override fun onUserIllegallyRequestedNextPage() {
+        Toast.makeText(context, "Please click on the checkbox to continue", Toast.LENGTH_SHORT).show()
+    }
+
+    companion object {
+        fun newInstance() = PrivacyPolicyFragment()
+    }
+}

--- a/example/src/main/res/layout/fragment_checkbox.xml
+++ b/example/src/main/res/layout/fragment_checkbox.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical">
+
+    <CheckBox
+        android:id="@+id/checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+
+</LinearLayout>


### PR DESCRIPTION
1. The **policy** slide can be skipped by pressing the SKIP button.
2. User can restart the application during slide shows (reset the first run flag ) and thus skip the user agreement slide