### PR TITLE
Deprecate the setNextPageSwipeLock method

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -238,22 +238,19 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
     }
 
     /**
-     * Setting to disable forward swiping right on current page and allow swiping left. If a swipe
-     * left occurs, the lock state is reset and swiping is re-enabled. (one shot disable) This also
-     * hides/shows the Next and Done buttons accordingly.
-     *
      * @param lock Set true to disable forward swiping. False to enable.
+     * @deprecated setNextPageSwipeLock has been deprecated in favor of setSwipeLock or SlidePolicy
      */
+    @Deprecated(
+        "setNextPageSwipeLock has been deprecated in favor of setSwipeLock or SlidePolicy",
+        ReplaceWith("setSwipeLock"),
+        DeprecationLevel.ERROR
+    )
     protected fun setNextPageSwipeLock(lock: Boolean) {
-        // We retain the button state in order to be able to restore
-        // it properly afterwards.
-        if (lock) {
-            retainIsButtonsEnabled = this.isButtonsEnabled
-            this.isButtonsEnabled = true
-        } else {
-            this.isButtonsEnabled = retainIsButtonsEnabled
-        }
-        pager.isNextPagingEnabled = !lock
+        LogHelper.w(
+            TAG,
+            "Calling setNextPageSwipeLock has not effect here. Please switch to setSwipeLock or SlidePolicy",
+        )
     }
 
     /**
@@ -482,10 +479,8 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
             putBoolean(ARG_BUNDLE_IS_SKIP_BUTTON_ENABLED, isSkipButtonEnabled)
             putBoolean(ARG_BUNDLE_IS_INDICATOR_ENABLED, isIndicatorEnabled)
 
-            putInt(ARG_BUNDLE_LOCK_PAGE, pager.lockPage)
             putInt(ARG_BUNDLE_CURRENT_ITEM, pager.currentItem)
             putBoolean(ARG_BUNDLE_IS_FULL_PAGING_ENABLED, pager.isFullPagingEnabled)
-            putBoolean(ARG_BUNDLE_IS_NEXT_PAGING_ENABLED, pager.isNextPagingEnabled)
 
             putSerializable(ARG_BUNDLE_PERMISSION_MAP, permissionsMap)
 
@@ -502,10 +497,8 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
             isSkipButtonEnabled = getBoolean(ARG_BUNDLE_IS_SKIP_BUTTON_ENABLED)
             isIndicatorEnabled = getBoolean(ARG_BUNDLE_IS_INDICATOR_ENABLED)
 
-            pager.lockPage = getInt(ARG_BUNDLE_LOCK_PAGE)
             savedCurrentItem = getInt(ARG_BUNDLE_CURRENT_ITEM)
             pager.isFullPagingEnabled = getBoolean(ARG_BUNDLE_IS_FULL_PAGING_ENABLED)
-            pager.isNextPagingEnabled = getBoolean(ARG_BUNDLE_IS_NEXT_PAGING_ENABLED)
 
             permissionsMap = (
                 (getSerializable(ARG_BUNDLE_PERMISSION_MAP) as HashMap<Int, PermissionWrapper>?)
@@ -774,15 +767,6 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
             if (slidesNumber >= 1) {
                 indicatorController?.selectPosition(position)
             }
-
-            // Allow the swipe to be re-enabled if a user swipes to a previous slide. Restore
-            // state of progress button depending on global progress button setting
-            if (!pager.isNextPagingEnabled) {
-                if (pager.currentItem != pager.lockPage) {
-                    isButtonsEnabled = retainIsButtonsEnabled
-                    pager.isNextPagingEnabled = true
-                }
-            }
             updateButtonsVisibility()
 
             pager.isPermissionSlide = this@AppIntroBase.isPermissionSlide
@@ -817,9 +801,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         private const val ARG_BUNDLE_IS_BUTTONS_ENABLED = "isButtonsEnabled"
         private const val ARG_BUNDLE_IS_FULL_PAGING_ENABLED = "isFullPagingEnabled"
         private const val ARG_BUNDLE_IS_INDICATOR_ENABLED = "isIndicatorEnabled"
-        private const val ARG_BUNDLE_IS_NEXT_PAGING_ENABLED = "isNextPagingEnabled"
         private const val ARG_BUNDLE_IS_SKIP_BUTTON_ENABLED = "isSkipButtonsEnabled"
-        private const val ARG_BUNDLE_LOCK_PAGE = "lockPage"
         private const val ARG_BUNDLE_PERMISSION_MAP = "permissionMap"
         private const val ARG_BUNDLE_RETAIN_IS_BUTTONS_ENABLED = "retainIsButtonsEnabled"
         private const val ARG_BUNDLE_SLIDES_NUMBER = "slidesNumber"

--- a/appintro/src/main/java/com/github/appintro/internal/AppIntroViewPager.kt
+++ b/appintro/src/main/java/com/github/appintro/internal/AppIntroViewPager.kt
@@ -12,28 +12,18 @@ import com.github.appintro.internal.viewpager.ViewPagerTransformer
 import kotlin.math.max
 
 /**
- * Class that controls the [AppIntro] of AppIntro.
+ * Class that controls the [ViewPager] of AppIntro.
  * This is responsible of handling of paging, managing touch and dispatching events.
  *
  * @property isFullPagingEnabled Enable or disable swiping at all.
  * @property isPermissionSlide If the current slide has permissions.
- * @property lockPage Set the page where the lock happened.
  * @property onNextPageRequestedListener Listener for Next Page events.
- * @property isNextPagingEnabled Enable or disable swiping to the next page.
  */
 internal class AppIntroViewPager(context: Context, attrs: AttributeSet) : ViewPager(context, attrs) {
 
     var isFullPagingEnabled = true
     var isPermissionSlide = false
-    var lockPage = 0
     var onNextPageRequestedListener: AppIntroViewPagerListener? = null
-    var isNextPagingEnabled: Boolean = true
-        set(value) {
-            field = value
-            if (!value) {
-                lockPage = currentItem
-            }
-        }
 
     private var currentTouchDownX: Float = 0.toFloat()
     private var currentTouchDownY: Float = 0.toFloat()


### PR DESCRIPTION
I'm deprecating the `setNextPageSwipeLock` method on `AppIntroBase`.

The method has no effect at all on the ViewPager and is causing confusion on the status of buttons if users happen to call it. We're going to remove the method in the upcoming major version of the library.

Fixes #902