### PR TITLE
Add support for Autosizing TextViews

### DIFF
--- a/appintro/src/main/res/values-sw600dp/dimen-sw600dp.xml
+++ b/appintro/src/main/res/values-sw600dp/dimen-sw600dp.xml
@@ -3,6 +3,8 @@
 
     <dimen name="appintro_desctext_size">30sp</dimen>
     <dimen name="appintro_headtext_size">42sp</dimen>
+    <dimen name="appintro_min_text_size">24sp</dimen>
+    <dimen name="appintro_text_granularity_size">2sp</dimen>
 
     <dimen name="appintro_button_margin">12dp</dimen>
     <dimen name="appintro_button_minheight">92dp</dimen>

--- a/appintro/src/main/res/values/dimen.xml
+++ b/appintro/src/main/res/values/dimen.xml
@@ -24,5 +24,7 @@
     <dimen name="appintro_headtext_size">28sp</dimen>
     <dimen name="appintro_skiptext_size">14sp</dimen>
     <dimen name="appintro_donetext_size">14sp</dimen>
+    <dimen name="appintro_min_text_size">12sp</dimen>
+    <dimen name="appintro_text_granularity_size">2sp</dimen>
 
 </resources>

--- a/appintro/src/main/res/values/styles.xml
+++ b/appintro/src/main/res/values/styles.xml
@@ -31,6 +31,10 @@
         <item name="android:textStyle">bold</item>
         <item name="android:padding">@dimen/appintro_head_padding</item>
         <item name="android:gravity">bottom|center_horizontal</item>
+        <item name="autoSizeTextType">uniform</item>
+        <item name="autoSizeMaxTextSize">@dimen/appintro_headtext_size</item>
+        <item name="autoSizeMinTextSize">@dimen/appintro_min_text_size</item>
+        <item name="autoSizeStepGranularity">@dimen/appintro_text_granularity_size</item>
     </style>
 
     <style name="AppIntroDefaultText" parent="TextAppearance.AppCompat.Body1">
@@ -38,6 +42,9 @@
         <item name="android:textSize">@dimen/appintro_desctext_size</item>
         <item name="android:padding">@dimen/appintro_desc_padding</item>
         <item name="android:gravity">center</item>
+        <item name="autoSizeMaxTextSize">@dimen/appintro_desctext_size</item>
+        <item name="autoSizeMinTextSize">@dimen/appintro_min_text_size</item>
+        <item name="autoSizeStepGranularity">@dimen/appintro_text_granularity_size</item>
     </style>
 
     <style name="AppIntroDefaultImage">


### PR DESCRIPTION
Fixes #915 

I'm adding Autosizing TextViews (https://developer.android.com/guide/topics/ui/look-and-feel/autosizing-textview) to fix problems with text being cut out.

| Long text | Short test |
| --- | --- |
| ![Screenshot_1611874511](https://user-images.githubusercontent.com/3001957/106209064-b4d0d000-61c4-11eb-8436-f1495e8096ae.png) | ![Screenshot_1611874513](https://user-images.githubusercontent.com/3001957/106209089-bac6b100-61c4-11eb-8334-3c9eeba08161.png) |

