### PR TITLE
Remove FoodTable from "Apps using AppIntro" (uses Flutter now)

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,7 +581,6 @@ If you are using AppIntro in your app and would like to be listed here, please o
 * [PrezziBenzina](https://play.google.com/store/apps/details?id=org.vernazza.androidfuel&hl=it)
 * [LogViewer for openHAB](https://github.com/cyb3rko/logviewer-for-openhab-app)
 * [Firmo con CIE](https://play.google.com/store/apps/details?id=com.cyberneid.disigoncie)
-* [FoodTable](https://play.google.com/store/apps/details?id=at.foodtable.app)
 * [iC-YOURLS](https://play.google.com/store/apps/details?id=net.inscomers.yourls)
 * [Secure File Manager](https://play.google.com/store/apps/details?id=com.securefilemanager.app)
 * [Noon Happen](https://play.google.com/store/apps/details?id=com.noonhappen.noonhappen)


### PR DESCRIPTION
Sad to go - but the app uses Flutter now.