### PR TITLE
Add note about onCreate() signature to avoid crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ class MyCustomAppIntro : AppIntro() {
 ```
 
 Please note that you **must NOT call** setContentView. The `AppIntro` superclass is taking care of it for you.
-Also confirm your signature of `onCreate(Bundle?)` only contains a single parameter as it will crash if it has a different signature. 
+
+Also confirm that you're overriding `onCreate` with **a single parameter** (`Bundle`) and you're not using another override (like `onCreate(Bundle, PersistableBundle)`) instead.
 
 Finally, declare the activity in your Manifest like so:
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ class MyCustomAppIntro : AppIntro() {
 ```
 
 Please note that you **must NOT call** setContentView. The `AppIntro` superclass is taking care of it for you.
+Also confirm your signature of `onCreate(Bundle?)` only contains a single parameter as it will crash if it has a different signature. 
 
 Finally, declare the activity in your Manifest like so:
 


### PR DESCRIPTION
Android Studio presents the wrong onCreate() function as first choice in autocomplete
which makes AppIntro crash with `IndexOutOfBoundsException`;
`onCreate(Bundle?, PersistableBundle?)` will not be called by the system.

See https://github.com/AppIntro/AppIntro/issues/836#issuecomment-841846605