### PR TITLE
Bump dependencies to fix lint on CI

### DIFF
--- a/appintro/build.gradle
+++ b/appintro/build.gradle
@@ -32,10 +32,10 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.annotation:annotation:1.2.0'
 
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.6.28'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 }


### PR DESCRIPTION
Seems like `lint` is broken on `master` due to several dependencies that are not up to date. I'm updating them.