### PR TITLE
Fix #926: Add color resource parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ class MyCustomAppIntro : AppIntro() {
 
         // Call addSlide passing your Fragments.
         // You can use AppIntroFragment to use a pre-built fragment
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 title = "Welcome...",
                 description = "This is the first slide of the example"
         ))
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 title = "...Let's get started!",
                 description = "This is the last slide, I won't annoy you more :)"
         ))
@@ -150,7 +150,7 @@ You can use the `AppIntroFragment` if you just want to customize title, descript
 That's the suggested approach if you want to create a quick intro:
 
 ```kotlin
-addSlide(AppIntroFragment.newInstance2(
+addSlide(AppIntroFragment.newInstanceWithRes(
     title = "The title of your slide",
     description = "A description that will be shown on the bottom",
     imageDrawable = R.drawable.the_central_icon,

--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ class MyCustomAppIntro : AppIntro() {
 
         // Call addSlide passing your Fragments.
         // You can use AppIntroFragment to use a pre-built fragment
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 title = "Welcome...",
                 description = "This is the first slide of the example"
         ))
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 title = "...Let's get started!",
                 description = "This is the last slide, I won't annoy you more :)"
         ))
@@ -150,14 +150,14 @@ You can use the `AppIntroFragment` if you just want to customize title, descript
 That's the suggested approach if you want to create a quick intro:
 
 ```kotlin
-addSlide(AppIntroFragment.newInstance(
+addSlide(AppIntroFragment.newInstance2(
     title = "The title of your slide",
     description = "A description that will be shown on the bottom",
     imageDrawable = R.drawable.the_central_icon,
     backgroundDrawable = R.drawable.the_background_image,
-    titleColor = Color.YELLOW,
-    descriptionColor = Color.RED,
-    backgroundColor = Color.BLUE,
+    titleColor = ContextCompat(context, R.color.yellow),
+    descriptionColor = ContextCompat(context, R.color.red),
+    backgroundColor = ContextCompat(context, R.color.blue),
     titleTypefaceFontRes = R.font.opensans_regular,
     descriptionTypefaceFontRes = R.font.opensans_regular,
 ))

--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -717,8 +717,8 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
             if (currentSlide.isAdded && nextSlide.isAdded) {
                 val newColor = argbEvaluator.evaluate(
                     positionOffset,
-                    currentSlide.defaultBackgroundColor,
-                    nextSlide.defaultBackgroundColor
+                        getSlideColor(currentSlide),
+                        getSlideColor(nextSlide)
                 ) as Int
                 currentSlide.setBackgroundColor(newColor)
                 nextSlide.setBackgroundColor(newColor)
@@ -726,6 +726,16 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         } else {
             error("Color transitions are only available if all slides implement SlideBackgroundColorHolder.")
         }
+    }
+
+    @ColorInt
+    @Suppress("DEPRECATION")
+    private fun getSlideColor(slide: SlideBackgroundColorHolder): Int {
+        if (slide.defaultBackgroundColorRes != 0) {
+            return ContextCompat.getColor(this, slide.defaultBackgroundColorRes)
+        }
+
+        return slide.defaultBackgroundColor
     }
 
     /**

--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -717,8 +717,8 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
             if (currentSlide.isAdded && nextSlide.isAdded) {
                 val newColor = argbEvaluator.evaluate(
                     positionOffset,
-                        getSlideColor(currentSlide),
-                        getSlideColor(nextSlide)
+                    getSlideColor(currentSlide),
+                    getSlideColor(nextSlide)
                 ) as Int
                 currentSlide.setBackgroundColor(newColor)
                 nextSlide.setBackgroundColor(newColor)

--- a/appintro/src/main/java/com/github/appintro/AppIntroBaseFragment.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBaseFragment.kt
@@ -31,7 +31,6 @@ internal const val ARG_DESC_COLOR = "desc_color"
 internal const val ARG_DESC_COLOR_RES = "desc_color_res"
 internal const val ARG_BG_DRAWABLE = "bg_drawable"
 
-
 abstract class AppIntroBaseFragment : Fragment(), SlideSelectionListener, SlideBackgroundColorHolder {
 
     private val logTAG = LogHelper.makeLogTag(AppIntroBaseFragment::class.java)

--- a/appintro/src/main/java/com/github/appintro/AppIntroBaseFragment.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBaseFragment.kt
@@ -8,8 +8,10 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.ColorInt
+import androidx.annotation.ColorRes
 import androidx.annotation.LayoutRes
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.github.appintro.internal.LogHelper
 import com.github.appintro.internal.TypefaceContainer
@@ -22,9 +24,13 @@ internal const val ARG_DESC_TYPEFACE = "desc_typeface"
 internal const val ARG_DESC_TYPEFACE_RES = "desc_typeface_res"
 internal const val ARG_DRAWABLE = "drawable"
 internal const val ARG_BG_COLOR = "bg_color"
+internal const val ARG_BG_COLOR_RES = "bg_color_res"
 internal const val ARG_TITLE_COLOR = "title_color"
+internal const val ARG_TITLE_COLOR_RES = "title_color_res"
 internal const val ARG_DESC_COLOR = "desc_color"
+internal const val ARG_DESC_COLOR_RES = "desc_color_res"
 internal const val ARG_BG_DRAWABLE = "bg_drawable"
+
 
 abstract class AppIntroBaseFragment : Fragment(), SlideSelectionListener, SlideBackgroundColorHolder {
 
@@ -36,9 +42,17 @@ abstract class AppIntroBaseFragment : Fragment(), SlideSelectionListener, SlideB
     private var drawable: Int = 0
     private var bgDrawable: Int = 0
 
-    private var titleColor: Int = 0
-    private var descColor: Int = 0
+    @ColorInt private var titleColor: Int = 0
+    @ColorRes private var titleColorRes: Int = 0
+    @ColorInt private var descColor: Int = 0
+    @ColorRes private var descColorRes: Int = 0
+
+    @ColorInt
     final override var defaultBackgroundColor: Int = 0
+        private set
+
+    @ColorRes
+    final override var defaultBackgroundColorRes: Int = 0
         private set
 
     private var title: String? = null
@@ -64,9 +78,13 @@ abstract class AppIntroBaseFragment : Fragment(), SlideSelectionListener, SlideB
             titleTypeface = TypefaceContainer(argsTitleTypeface, argsTitleTypefaceRes)
             descTypeface = TypefaceContainer(argsDescTypeface, argsDescTypefaceRes)
 
+            @Suppress("DEPRECATION")
             defaultBackgroundColor = args.getInt(ARG_BG_COLOR)
+            defaultBackgroundColorRes = args.getInt(ARG_BG_COLOR_RES)
             titleColor = args.getInt(ARG_TITLE_COLOR, 0)
+            titleColorRes = args.getInt(ARG_TITLE_COLOR_RES, 0)
             descColor = args.getInt(ARG_DESC_COLOR, 0)
+            descColorRes = args.getInt(ARG_DESC_COLOR_RES, 0)
         }
     }
 
@@ -87,10 +105,14 @@ abstract class AppIntroBaseFragment : Fragment(), SlideSelectionListener, SlideB
                 savedInstanceState.getInt(ARG_DESC_TYPEFACE_RES, 0)
             )
 
+            @Suppress("DEPRECATION")
             defaultBackgroundColor = savedInstanceState.getInt(ARG_BG_COLOR)
+            defaultBackgroundColorRes = savedInstanceState.getInt(ARG_BG_COLOR_RES)
             bgDrawable = savedInstanceState.getInt(ARG_BG_DRAWABLE)
             titleColor = savedInstanceState.getInt(ARG_TITLE_COLOR)
+            titleColorRes = savedInstanceState.getInt(ARG_TITLE_COLOR_RES)
             descColor = savedInstanceState.getInt(ARG_DESC_COLOR)
+            descColorRes = savedInstanceState.getInt(ARG_DESC_COLOR_RES)
         }
     }
 
@@ -107,20 +129,33 @@ abstract class AppIntroBaseFragment : Fragment(), SlideSelectionListener, SlideB
 
         titleText.text = title
         descriptionText.text = description
-        if (titleColor != 0) {
+
+        if (titleColorRes != 0) {
+            titleText.setTextColor(ContextCompat.getColor(requireContext(), titleColorRes))
+        } else if (titleColor != 0) { // Fallback to deprecated static color
             titleText.setTextColor(titleColor)
         }
-        if (descColor != 0) {
+        if (descColorRes != 0) {
+            descriptionText.setTextColor(ContextCompat.getColor(requireContext(), descColorRes))
+        } else if (descColor != 0) { // Fallback to deprecated static color
             descriptionText.setTextColor(descColor)
         }
+
         titleTypeface?.applyTo(titleText)
         descTypeface?.applyTo(descriptionText)
 
         slideImage.setImageResource(drawable)
-        if (bgDrawable != 0) {
-            mainLayout?.setBackgroundResource(bgDrawable)
-        } else {
-            mainLayout?.setBackgroundColor(defaultBackgroundColor)
+        when {
+            bgDrawable != 0 -> {
+                mainLayout?.setBackgroundResource(bgDrawable)
+            }
+            defaultBackgroundColorRes != 0 -> {
+                mainLayout?.setBackgroundColor(ContextCompat.getColor(requireContext(), defaultBackgroundColorRes))
+            }
+            else -> {
+                @Suppress("DEPRECATION")
+                mainLayout?.setBackgroundColor(defaultBackgroundColor)
+            }
         }
 
         return view
@@ -151,9 +186,13 @@ abstract class AppIntroBaseFragment : Fragment(), SlideSelectionListener, SlideB
         outState.putInt(ARG_BG_DRAWABLE, bgDrawable)
         outState.putString(ARG_TITLE, title)
         outState.putString(ARG_DESC, description)
+        @Suppress("DEPRECATION")
         outState.putInt(ARG_BG_COLOR, defaultBackgroundColor)
+        outState.putInt(ARG_BG_COLOR_RES, defaultBackgroundColorRes)
         outState.putInt(ARG_TITLE_COLOR, titleColor)
+        outState.putInt(ARG_TITLE_COLOR_RES, titleColorRes)
         outState.putInt(ARG_DESC_COLOR, descColor)
+        outState.putInt(ARG_DESC_COLOR_RES, descColorRes)
         if (titleTypeface != null) {
             outState.putString(ARG_TITLE_TYPEFACE, titleTypeface?.typeFaceUrl)
             outState.putInt(ARG_TITLE_TYPEFACE_RES, titleTypeface?.typeFaceResource ?: 0)

--- a/appintro/src/main/java/com/github/appintro/AppIntroFragment.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroFragment.kt
@@ -36,7 +36,7 @@ class AppIntroFragment : AppIntroBaseFragment() {
         @Deprecated(
             "`newInstance` is deprecated to support color resources with configuration " +
                     "changes",
-            ReplaceWith("newInstance2(title, description, imageDrawable, backgroundColor," +
+            ReplaceWith("newInstanceWithRes(title, description, imageDrawable, backgroundColor," +
                     " titleColor, descriptionColor, titleTypefaceFontRes, descriptionTypefaceFontRes, " +
                     "backgroundDrawable)")
         )
@@ -86,7 +86,7 @@ class AppIntroFragment : AppIntroBaseFragment() {
          */
         @JvmOverloads
         @JvmStatic
-        fun newInstance2(
+        fun newInstanceWithRes(
             title: CharSequence? = null,
             description: CharSequence? = null,
             @DrawableRes imageDrawable: Int = 0,

--- a/appintro/src/main/java/com/github/appintro/AppIntroFragment.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroFragment.kt
@@ -1,6 +1,5 @@
 package com.github.appintro
 
-import android.os.Bundle
 import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
@@ -35,8 +34,11 @@ class AppIntroFragment : AppIntroBaseFragment() {
         @JvmOverloads
         @JvmStatic
         @Deprecated(
-                "`newInstance` is deprecated to support color resources with configuration changes",
-                ReplaceWith("newInstance2(title, description, imageDrawable, backgroundColor, titleColor, descriptionColor, titleTypefaceFontRes, descriptionTypefaceFontRes, backgroundDrawable)")
+            "`newInstance` is deprecated to support color resources with configuration " +
+                    "changes",
+            ReplaceWith("newInstance2(title, description, imageDrawable, backgroundColor," +
+                    " titleColor, descriptionColor, titleTypefaceFontRes, descriptionTypefaceFontRes, " +
+                    "backgroundDrawable)")
         )
         fun newInstance(
             title: CharSequence? = null,
@@ -85,28 +87,28 @@ class AppIntroFragment : AppIntroBaseFragment() {
         @JvmOverloads
         @JvmStatic
         fun newInstance2(
-                title: CharSequence? = null,
-                description: CharSequence? = null,
-                @DrawableRes imageDrawable: Int = 0,
-                @ColorRes backgroundColorRes: Int = 0,
-                @ColorRes titleColorRes: Int = 0,
-                @ColorRes descriptionColorRes: Int = 0,
-                @FontRes titleTypefaceFontRes: Int = 0,
-                @FontRes descriptionTypefaceFontRes: Int = 0,
-                @DrawableRes backgroundDrawable: Int = 0
+            title: CharSequence? = null,
+            description: CharSequence? = null,
+            @DrawableRes imageDrawable: Int = 0,
+            @ColorRes backgroundColorRes: Int = 0,
+            @ColorRes titleColorRes: Int = 0,
+            @ColorRes descriptionColorRes: Int = 0,
+            @FontRes titleTypefaceFontRes: Int = 0,
+            @FontRes descriptionTypefaceFontRes: Int = 0,
+            @DrawableRes backgroundDrawable: Int = 0
         ): AppIntroFragment {
             return newInstance(
-                    SliderPage(
-                            title = title,
-                            description = description,
-                            imageDrawable = imageDrawable,
-                            backgroundColorRes = backgroundColorRes,
-                            titleColorRes = titleColorRes,
-                            descriptionColorRes = descriptionColorRes,
-                            titleTypefaceFontRes = titleTypefaceFontRes,
-                            descriptionTypefaceFontRes = descriptionTypefaceFontRes,
-                            backgroundDrawable = backgroundDrawable
-                    )
+                SliderPage(
+                    title = title,
+                    description = description,
+                    imageDrawable = imageDrawable,
+                    backgroundColorRes = backgroundColorRes,
+                    titleColorRes = titleColorRes,
+                    descriptionColorRes = descriptionColorRes,
+                    titleTypefaceFontRes = titleTypefaceFontRes,
+                    descriptionTypefaceFontRes = descriptionTypefaceFontRes,
+                    backgroundDrawable = backgroundDrawable
+                )
             )
         }
 

--- a/appintro/src/main/java/com/github/appintro/AppIntroFragment.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroFragment.kt
@@ -1,6 +1,8 @@
 package com.github.appintro
 
+import android.os.Bundle
 import androidx.annotation.ColorInt
+import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.FontRes
 import com.github.appintro.model.SliderPage
@@ -32,6 +34,10 @@ class AppIntroFragment : AppIntroBaseFragment() {
          */
         @JvmOverloads
         @JvmStatic
+        @Deprecated(
+                "`newInstance` is deprecated to support color resources with configuration changes",
+                ReplaceWith("newInstance2(title, description, imageDrawable, backgroundColor, titleColor, descriptionColor, titleTypefaceFontRes, descriptionTypefaceFontRes, backgroundDrawable)")
+        )
         fun newInstance(
             title: CharSequence? = null,
             description: CharSequence? = null,
@@ -55,6 +61,52 @@ class AppIntroFragment : AppIntroBaseFragment() {
                     descriptionTypefaceFontRes = descriptionTypefaceFontRes,
                     backgroundDrawable = backgroundDrawable
                 )
+            )
+        }
+
+        /**
+         * Generates a new instance for [AppIntroFragment]
+         *
+         * @param title CharSequence which will be the slide title
+         * @param description CharSequence which will be the slide description
+         * @param imageDrawable @DrawableRes (Integer) the image that will be
+         *                             displayed, obtained from Resources
+         * @param backgroundColorRes @ColorRes (Integer) custom background color
+         * @param titleColorRes @ColorRes (Integer) custom title color
+         * @param descriptionColorRes @ColorRes (Integer) custom description color
+         * @param titleTypefaceFontRes @FontRes (Integer) custom title typeface obtained
+         *                             from Resources
+         * @param descriptionTypefaceFontRes @FontRes (Integer) custom description typeface obtained
+         *                             from Resources
+         * @param backgroundDrawable @DrawableRes (Integer) custom background drawable
+         *
+         * @return An [AppIntroFragment] created instance
+         */
+        @JvmOverloads
+        @JvmStatic
+        fun newInstance2(
+                title: CharSequence? = null,
+                description: CharSequence? = null,
+                @DrawableRes imageDrawable: Int = 0,
+                @ColorRes backgroundColorRes: Int = 0,
+                @ColorRes titleColorRes: Int = 0,
+                @ColorRes descriptionColorRes: Int = 0,
+                @FontRes titleTypefaceFontRes: Int = 0,
+                @FontRes descriptionTypefaceFontRes: Int = 0,
+                @DrawableRes backgroundDrawable: Int = 0
+        ): AppIntroFragment {
+            return newInstance(
+                    SliderPage(
+                            title = title,
+                            description = description,
+                            imageDrawable = imageDrawable,
+                            backgroundColorRes = backgroundColorRes,
+                            titleColorRes = titleColorRes,
+                            descriptionColorRes = descriptionColorRes,
+                            titleTypefaceFontRes = titleTypefaceFontRes,
+                            descriptionTypefaceFontRes = descriptionTypefaceFontRes,
+                            backgroundDrawable = backgroundDrawable
+                    )
             )
         }
 

--- a/appintro/src/main/java/com/github/appintro/AppIntroFragment.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroFragment.kt
@@ -35,10 +35,12 @@ class AppIntroFragment : AppIntroBaseFragment() {
         @JvmStatic
         @Deprecated(
             "`newInstance` is deprecated to support color resources with configuration " +
-                    "changes",
-            ReplaceWith("newInstanceWithRes(title, description, imageDrawable, backgroundColor," +
-                    " titleColor, descriptionColor, titleTypefaceFontRes, descriptionTypefaceFontRes, " +
-                    "backgroundDrawable)")
+                "changes",
+            ReplaceWith(
+                "newInstanceWithRes(title, description, imageDrawable, backgroundColor, " +
+                    "titleColor, descriptionColor, titleTypefaceFontRes, descriptionTypefaceFontRes, " +
+                    "backgroundDrawable)"
+            )
         )
         fun newInstance(
             title: CharSequence? = null,

--- a/appintro/src/main/java/com/github/appintro/SlideBackgroundColorHolder.kt
+++ b/appintro/src/main/java/com/github/appintro/SlideBackgroundColorHolder.kt
@@ -1,6 +1,7 @@
 package com.github.appintro
 
 import androidx.annotation.ColorInt
+import androidx.annotation.ColorRes
 
 interface SlideBackgroundColorHolder {
 
@@ -10,7 +11,19 @@ interface SlideBackgroundColorHolder {
      * @return The default background color of the slide
      */
     @get:ColorInt
+    @Deprecated(
+            "`defaultBackgroundColor` has been deprecated to support configuration changes",
+            ReplaceWith("defaultBackgroundColorRes")
+    )
     val defaultBackgroundColor: Int
+
+    /**
+     * Returns the default background color of the slide
+     *
+     * @return The default background color of the slide
+     */
+    @get:ColorRes
+    val defaultBackgroundColorRes: Int
 
     /**
      * Sets the actual background color of the slide. This does not affect the default background color.

--- a/appintro/src/main/java/com/github/appintro/SlideBackgroundColorHolder.kt
+++ b/appintro/src/main/java/com/github/appintro/SlideBackgroundColorHolder.kt
@@ -12,8 +12,8 @@ interface SlideBackgroundColorHolder {
      */
     @get:ColorInt
     @Deprecated(
-            "`defaultBackgroundColor` has been deprecated to support configuration changes",
-            ReplaceWith("defaultBackgroundColorRes")
+        "`defaultBackgroundColor` has been deprecated to support configuration changes",
+        ReplaceWith("defaultBackgroundColorRes")
     )
     val defaultBackgroundColor: Int
 

--- a/appintro/src/main/java/com/github/appintro/model/SliderPage.kt
+++ b/appintro/src/main/java/com/github/appintro/model/SliderPage.kt
@@ -26,39 +26,39 @@ import com.github.appintro.ARG_TITLE_TYPEFACE_RES
  * This data class represent a single page that can be visualized with AppIntro.
  */
 data class SliderPage @JvmOverloads constructor(
-        var title: CharSequence? = null,
-        var description: CharSequence? = null,
-        @DrawableRes var imageDrawable: Int = 0,
+    var title: CharSequence? = null,
+    var description: CharSequence? = null,
+    @DrawableRes var imageDrawable: Int = 0,
 
-        @ColorInt
-        @Deprecated(
-                "`backgroundColor` has been deprecated to support configuration changes",
-                ReplaceWith("backgroundColorRes")
-        )
-        var backgroundColor: Int = 0,
+    @ColorInt
+    @Deprecated(
+        "`backgroundColor` has been deprecated to support configuration changes",
+        ReplaceWith("backgroundColorRes")
+    )
+    var backgroundColor: Int = 0,
 
-        @ColorInt
-        @Deprecated(
-                "`titleColor` has been deprecated to support configuration changes",
-                ReplaceWith("titleColorRes")
-        )
-        var titleColor: Int = 0,
+    @ColorInt
+    @Deprecated(
+        "`titleColor` has been deprecated to support configuration changes",
+        ReplaceWith("titleColorRes")
+    )
+    var titleColor: Int = 0,
 
-        @ColorInt
-        @Deprecated(
-                "`descriptionColor` has been deprecated to support configuration changes",
-                ReplaceWith("descriptionColorRes")
-        )
-        var descriptionColor: Int = 0,
+    @ColorInt
+    @Deprecated(
+        "`descriptionColor` has been deprecated to support configuration changes",
+        ReplaceWith("descriptionColorRes")
+    )
+    var descriptionColor: Int = 0,
 
-        @ColorRes var backgroundColorRes: Int = 0,
-        @ColorRes var titleColorRes: Int = 0,
-        @ColorRes var descriptionColorRes: Int = 0,
-        @FontRes var titleTypefaceFontRes: Int = 0,
-        @FontRes var descriptionTypefaceFontRes: Int = 0,
-        var titleTypeface: String? = null,
-        var descriptionTypeface: String? = null,
-        @DrawableRes var backgroundDrawable: Int = 0
+    @ColorRes var backgroundColorRes: Int = 0,
+    @ColorRes var titleColorRes: Int = 0,
+    @ColorRes var descriptionColorRes: Int = 0,
+    @FontRes var titleTypefaceFontRes: Int = 0,
+    @FontRes var descriptionTypefaceFontRes: Int = 0,
+    var titleTypeface: String? = null,
+    var descriptionTypeface: String? = null,
+    @DrawableRes var backgroundDrawable: Int = 0
 ) {
     val titleString: String? get() = title?.toString()
     val descriptionString: String? get() = description?.toString()

--- a/appintro/src/main/java/com/github/appintro/model/SliderPage.kt
+++ b/appintro/src/main/java/com/github/appintro/model/SliderPage.kt
@@ -2,17 +2,21 @@ package com.github.appintro.model
 
 import android.os.Bundle
 import androidx.annotation.ColorInt
+import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.FontRes
 import com.github.appintro.ARG_BG_COLOR
+import com.github.appintro.ARG_BG_COLOR_RES
 import com.github.appintro.ARG_BG_DRAWABLE
 import com.github.appintro.ARG_DESC
 import com.github.appintro.ARG_DESC_COLOR
+import com.github.appintro.ARG_DESC_COLOR_RES
 import com.github.appintro.ARG_DESC_TYPEFACE
 import com.github.appintro.ARG_DESC_TYPEFACE_RES
 import com.github.appintro.ARG_DRAWABLE
 import com.github.appintro.ARG_TITLE
 import com.github.appintro.ARG_TITLE_COLOR
+import com.github.appintro.ARG_TITLE_COLOR_RES
 import com.github.appintro.ARG_TITLE_TYPEFACE
 import com.github.appintro.ARG_TITLE_TYPEFACE_RES
 
@@ -22,17 +26,39 @@ import com.github.appintro.ARG_TITLE_TYPEFACE_RES
  * This data class represent a single page that can be visualized with AppIntro.
  */
 data class SliderPage @JvmOverloads constructor(
-    var title: CharSequence? = null,
-    var description: CharSequence? = null,
-    @DrawableRes var imageDrawable: Int = 0,
-    @ColorInt var backgroundColor: Int = 0,
-    @ColorInt var titleColor: Int = 0,
-    @ColorInt var descriptionColor: Int = 0,
-    @FontRes var titleTypefaceFontRes: Int = 0,
-    @FontRes var descriptionTypefaceFontRes: Int = 0,
-    var titleTypeface: String? = null,
-    var descriptionTypeface: String? = null,
-    @DrawableRes var backgroundDrawable: Int = 0
+        var title: CharSequence? = null,
+        var description: CharSequence? = null,
+        @DrawableRes var imageDrawable: Int = 0,
+
+        @ColorInt
+        @Deprecated(
+                "`backgroundColor` has been deprecated to support configuration changes",
+                ReplaceWith("backgroundColorRes")
+        )
+        var backgroundColor: Int = 0,
+
+        @ColorInt
+        @Deprecated(
+                "`titleColor` has been deprecated to support configuration changes",
+                ReplaceWith("titleColorRes")
+        )
+        var titleColor: Int = 0,
+
+        @ColorInt
+        @Deprecated(
+                "`descriptionColor` has been deprecated to support configuration changes",
+                ReplaceWith("descriptionColorRes")
+        )
+        var descriptionColor: Int = 0,
+
+        @ColorRes var backgroundColorRes: Int = 0,
+        @ColorRes var titleColorRes: Int = 0,
+        @ColorRes var descriptionColorRes: Int = 0,
+        @FontRes var titleTypefaceFontRes: Int = 0,
+        @FontRes var descriptionTypefaceFontRes: Int = 0,
+        var titleTypeface: String? = null,
+        var descriptionTypeface: String? = null,
+        @DrawableRes var backgroundDrawable: Int = 0
 ) {
     val titleString: String? get() = title?.toString()
     val descriptionString: String? get() = description?.toString()
@@ -47,12 +73,15 @@ data class SliderPage @JvmOverloads constructor(
         newBundle.putString(ARG_TITLE_TYPEFACE, this.titleTypeface)
         newBundle.putInt(ARG_TITLE_TYPEFACE_RES, this.titleTypefaceFontRes)
         newBundle.putInt(ARG_TITLE_COLOR, this.titleColor)
+        newBundle.putInt(ARG_TITLE_COLOR_RES, this.titleColorRes)
         newBundle.putString(ARG_DESC, this.descriptionString)
         newBundle.putString(ARG_DESC_TYPEFACE, this.descriptionTypeface)
         newBundle.putInt(ARG_DESC_TYPEFACE_RES, this.descriptionTypefaceFontRes)
         newBundle.putInt(ARG_DESC_COLOR, this.descriptionColor)
+        newBundle.putInt(ARG_DESC_COLOR_RES, this.descriptionColorRes)
         newBundle.putInt(ARG_DRAWABLE, this.imageDrawable)
         newBundle.putInt(ARG_BG_COLOR, this.backgroundColor)
+        newBundle.putInt(ARG_BG_COLOR_RES, this.backgroundColorRes)
         newBundle.putInt(ARG_BG_DRAWABLE, this.backgroundDrawable)
         return newBundle
     }

--- a/appintro/src/main/java/com/github/appintro/model/SliderPagerBuilder.kt
+++ b/appintro/src/main/java/com/github/appintro/model/SliderPagerBuilder.kt
@@ -66,8 +66,8 @@ class SliderPagerBuilder {
     }
 
     @Deprecated(
-            "`backgroundColor(...)` has been deprecated to support configuration changes",
-            ReplaceWith("backgroundColorRes(backgroundColor)")
+        "`backgroundColor(...)` has been deprecated to support configuration changes",
+        ReplaceWith("backgroundColorRes(backgroundColor)")
     )
     fun backgroundColor(@ColorInt backgroundColor: Int): SliderPagerBuilder {
         this.backgroundColor = backgroundColor
@@ -80,8 +80,8 @@ class SliderPagerBuilder {
     }
 
     @Deprecated(
-            "`titleColor(...)` has been deprecated to support configuration changes",
-            ReplaceWith("titleColorRes(titleColor)")
+        "`titleColor(...)` has been deprecated to support configuration changes",
+        ReplaceWith("titleColorRes(titleColor)")
     )
     fun titleColor(@ColorInt titleColor: Int): SliderPagerBuilder {
         this.titleColor = titleColor
@@ -94,8 +94,8 @@ class SliderPagerBuilder {
     }
 
     @Deprecated(
-            "`descriptionColor(...)` has been deprecated to support configuration changes",
-            ReplaceWith("descriptionColorRes(descriptionColor)")
+        "`descriptionColor(...)` has been deprecated to support configuration changes",
+        ReplaceWith("descriptionColorRes(descriptionColor)")
     )
     fun descriptionColor(@ColorInt descriptionColor: Int): SliderPagerBuilder {
         this.descriptionColor = descriptionColor

--- a/appintro/src/main/java/com/github/appintro/model/SliderPagerBuilder.kt
+++ b/appintro/src/main/java/com/github/appintro/model/SliderPagerBuilder.kt
@@ -1,6 +1,7 @@
 package com.github.appintro.model
 
 import androidx.annotation.ColorInt
+import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.FontRes
 
@@ -21,11 +22,20 @@ class SliderPagerBuilder {
     @ColorInt
     private var backgroundColor: Int = 0
 
+    @ColorRes
+    private var backgroundColorRes: Int = 0
+
     @ColorInt
     private var titleColor: Int = 0
 
+    @ColorRes
+    private var titleColorRes: Int = 0
+
     @ColorInt
     private var descriptionColor: Int = 0
+
+    @ColorRes
+    private var descriptionColorRes: Int = 0
 
     @FontRes
     private var titleTypefaceFontRes: Int = 0
@@ -55,18 +65,45 @@ class SliderPagerBuilder {
         return this
     }
 
+    @Deprecated(
+            "`backgroundColor(...)` has been deprecated to support configuration changes",
+            ReplaceWith("backgroundColorRes(backgroundColor)")
+    )
     fun backgroundColor(@ColorInt backgroundColor: Int): SliderPagerBuilder {
         this.backgroundColor = backgroundColor
         return this
     }
 
+    fun backgroundColorRes(@ColorRes backgroundColorRes: Int): SliderPagerBuilder {
+        this.backgroundColorRes = backgroundColorRes
+        return this
+    }
+
+    @Deprecated(
+            "`titleColor(...)` has been deprecated to support configuration changes",
+            ReplaceWith("titleColorRes(titleColor)")
+    )
     fun titleColor(@ColorInt titleColor: Int): SliderPagerBuilder {
         this.titleColor = titleColor
         return this
     }
 
+    fun titleColorRes(@ColorRes titleColorRes: Int): SliderPagerBuilder {
+        this.titleColorRes = titleColorRes
+        return this
+    }
+
+    @Deprecated(
+            "`descriptionColor(...)` has been deprecated to support configuration changes",
+            ReplaceWith("descriptionColorRes(descriptionColor)")
+    )
     fun descriptionColor(@ColorInt descriptionColor: Int): SliderPagerBuilder {
         this.descriptionColor = descriptionColor
+        return this
+    }
+
+    fun descriptionColorRes(@ColorRes descriptionColorRes: Int): SliderPagerBuilder {
+        this.descriptionColorRes = descriptionColorRes
         return this
     }
 
@@ -100,8 +137,11 @@ class SliderPagerBuilder {
         description = this.description,
         imageDrawable = this.imageDrawable,
         backgroundColor = this.backgroundColor,
+        backgroundColorRes = this.backgroundColorRes,
         titleColor = this.titleColor,
+        titleColorRes = this.titleColorRes,
         descriptionColor = this.descriptionColor,
+        descriptionColorRes = this.descriptionColorRes,
         titleTypefaceFontRes = this.titleTypefaceFontRes,
         descriptionTypeface = this.descriptionTypeface,
         titleTypeface = this.titleTypeface,

--- a/example/src/main/java/com/github/appintro/example/ui/custom/CustomBackgroundIntro.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/custom/CustomBackgroundIntro.kt
@@ -11,25 +11,25 @@ class CustomBackgroundIntro : AppIntro2() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Welcome!",
                 "This is a demo of the AppIntro library, with a custom background on each slide!",
                 imageDrawable = R.drawable.ic_slide1
         ))
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Clean App Intros",
                 "This library offers developers the ability to add clean app intros at the start of their apps.",
                 imageDrawable = R.drawable.ic_slide2
         ))
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Simple, yet Customizable",
                 "The library offers a lot of customization, while keeping it simple for those that like simple.",
                 imageDrawable = R.drawable.ic_slide3
         ))
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Explore",
                 "Feel free to explore the rest of the library demo!",
                 imageDrawable = R.drawable.ic_slide4

--- a/example/src/main/java/com/github/appintro/example/ui/custom/CustomBackgroundIntro.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/custom/CustomBackgroundIntro.kt
@@ -11,25 +11,25 @@ class CustomBackgroundIntro : AppIntro2() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Welcome!",
                 "This is a demo of the AppIntro library, with a custom background on each slide!",
                 imageDrawable = R.drawable.ic_slide1
         ))
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Clean App Intros",
                 "This library offers developers the ability to add clean app intros at the start of their apps.",
                 imageDrawable = R.drawable.ic_slide2
         ))
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Simple, yet Customizable",
                 "The library offers a lot of customization, while keeping it simple for those that like simple.",
                 imageDrawable = R.drawable.ic_slide3
         ))
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Explore",
                 "Feel free to explore the rest of the library demo!",
                 imageDrawable = R.drawable.ic_slide4

--- a/example/src/main/java/com/github/appintro/example/ui/custom/SlidePolicyIntro.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/custom/SlidePolicyIntro.kt
@@ -10,14 +10,14 @@ class SlidePolicyIntro : AppIntro() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Welcome",
                 "This is a demo of the AppIntro library, using the SlidePolicy feature."
         ))
 
         addSlide(CustomSlidePolicyFragment.newInstance())
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Policy Respected!",
                 "If the user arrived here, the SlidePolicy was respected."
         ))

--- a/example/src/main/java/com/github/appintro/example/ui/custom/SlidePolicyIntro.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/custom/SlidePolicyIntro.kt
@@ -10,14 +10,14 @@ class SlidePolicyIntro : AppIntro() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Welcome",
                 "This is a demo of the AppIntro library, using the SlidePolicy feature."
         ))
 
         addSlide(CustomSlidePolicyFragment.newInstance())
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Policy Respected!",
                 "If the user arrived here, the SlidePolicy was respected."
         ))

--- a/example/src/main/java/com/github/appintro/example/ui/default/DefaultIntro.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/default/DefaultIntro.kt
@@ -10,25 +10,25 @@ class DefaultIntro : AppIntro() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Welcome!",
                 "This is a demo of the AppIntro library, with a custom background on each slide!",
                 imageDrawable = R.drawable.ic_slide1
         ))
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Clean App Intros",
                 "This library offers developers the ability to add clean app intros at the start of their apps.",
                 imageDrawable = R.drawable.ic_slide2
         ))
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Simple, yet Customizable",
                 "The library offers a lot of customization, while keeping it simple for those that like simple.",
                 imageDrawable = R.drawable.ic_slide3
         ))
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Explore",
                 "Feel free to explore the rest of the library demo!",
                 imageDrawable = R.drawable.ic_slide4

--- a/example/src/main/java/com/github/appintro/example/ui/default/DefaultIntro.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/default/DefaultIntro.kt
@@ -10,25 +10,25 @@ class DefaultIntro : AppIntro() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Welcome!",
                 "This is a demo of the AppIntro library, with a custom background on each slide!",
                 imageDrawable = R.drawable.ic_slide1
         ))
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Clean App Intros",
                 "This library offers developers the ability to add clean app intros at the start of their apps.",
                 imageDrawable = R.drawable.ic_slide2
         ))
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Simple, yet Customizable",
                 "The library offers a lot of customization, while keeping it simple for those that like simple.",
                 imageDrawable = R.drawable.ic_slide3
         ))
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Explore",
                 "Feel free to explore the rest of the library demo!",
                 imageDrawable = R.drawable.ic_slide4

--- a/example/src/main/java/com/github/appintro/example/ui/default/DefaultIntro2.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/default/DefaultIntro2.kt
@@ -12,7 +12,7 @@ class DefaultIntro2 : AppIntro2() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Welcome!",
                 "This is a demo of the AppIntro library, using the second layout.",
                 imageDrawable = R.drawable.ic_slide1,
@@ -30,7 +30,7 @@ class DefaultIntro2 : AppIntro2() {
                 descriptionTypeface = "OpenSans-Light.ttf"
         )))
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Simple, yet Customizable",
                 "The library offers a lot of customization, while keeping it simple for those that like simple.",
                 imageDrawable = R.drawable.ic_slide3,
@@ -39,14 +39,14 @@ class DefaultIntro2 : AppIntro2() {
                 descriptionTypefaceFontRes = R.font.opensans_regular
         ))
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Explore",
                 "Feel free to explore the rest of the library demo!",
                 imageDrawable = R.drawable.ic_slide4,
                 backgroundDrawable = R.drawable.back_slide4
         ))
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 ":)",
                 "...gradients are awesome!",
                 imageDrawable = R.mipmap.ic_launcher,

--- a/example/src/main/java/com/github/appintro/example/ui/default/DefaultIntro2.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/default/DefaultIntro2.kt
@@ -12,7 +12,7 @@ class DefaultIntro2 : AppIntro2() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Welcome!",
                 "This is a demo of the AppIntro library, using the second layout.",
                 imageDrawable = R.drawable.ic_slide1,
@@ -30,7 +30,7 @@ class DefaultIntro2 : AppIntro2() {
                 descriptionTypeface = "OpenSans-Light.ttf"
         )))
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Simple, yet Customizable",
                 "The library offers a lot of customization, while keeping it simple for those that like simple.",
                 imageDrawable = R.drawable.ic_slide3,
@@ -39,14 +39,14 @@ class DefaultIntro2 : AppIntro2() {
                 descriptionTypefaceFontRes = R.font.opensans_regular
         ))
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Explore",
                 "Feel free to explore the rest of the library demo!",
                 imageDrawable = R.drawable.ic_slide4,
                 backgroundDrawable = R.drawable.back_slide4
         ))
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 ":)",
                 "...gradients are awesome!",
                 imageDrawable = R.mipmap.ic_launcher,

--- a/example/src/main/java/com/github/appintro/example/ui/java/JavaIntro.java
+++ b/example/src/main/java/com/github/appintro/example/ui/java/JavaIntro.java
@@ -16,23 +16,23 @@ public class JavaIntro extends AppIntro {
         super.onCreate(savedInstanceState);
 
 
-        addSlide(AppIntroFragment.newInstance2("Welcome!",
+        addSlide(AppIntroFragment.newInstanceWithRes("Welcome!",
                 "This is a demo example in java of AppIntro library, with a custom background on each slide!",
                 R.drawable.ic_slide1));
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Clean App Intros",
                 "This library offers developers the ability to add clean app intros at the start of their apps.",
                 R.drawable.ic_slide2
         ));
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Simple, yet Customizable",
                 "The library offers a lot of customization, while keeping it simple for those that like simple.",
                 R.drawable.ic_slide3
         ));
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Explore",
                 "Feel free to explore the rest of the library demo!",
                 R.drawable.ic_slide4

--- a/example/src/main/java/com/github/appintro/example/ui/java/JavaIntro.java
+++ b/example/src/main/java/com/github/appintro/example/ui/java/JavaIntro.java
@@ -16,23 +16,23 @@ public class JavaIntro extends AppIntro {
         super.onCreate(savedInstanceState);
 
 
-        addSlide(AppIntroFragment.newInstance("Welcome!",
+        addSlide(AppIntroFragment.newInstance2("Welcome!",
                 "This is a demo example in java of AppIntro library, with a custom background on each slide!",
                 R.drawable.ic_slide1));
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Clean App Intros",
                 "This library offers developers the ability to add clean app intros at the start of their apps.",
                 R.drawable.ic_slide2
         ));
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Simple, yet Customizable",
                 "The library offers a lot of customization, while keeping it simple for those that like simple.",
                 R.drawable.ic_slide3
         ));
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Explore",
                 "Feel free to explore the rest of the library demo!",
                 R.drawable.ic_slide4

--- a/example/src/main/java/com/github/appintro/example/ui/permissions/PermissionsIntro.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/permissions/PermissionsIntro.kt
@@ -11,22 +11,22 @@ class PermissionsIntro : AppIntro() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Welcome!",
                 "This is a demo of the AppIntro library, with permissions being requested on a slide!",
                 imageDrawable = R.drawable.ic_slide1))
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Permission Request",
                 "In order to access your camera, you must give permissions.",
                 imageDrawable = R.drawable.ic_slide2))
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Simple, yet Customizable",
                 "The library offers a lot of customization, while keeping it simple for those that like simple.",
                 imageDrawable = R.drawable.ic_slide3))
 
-        addSlide(AppIntroFragment.newInstance2(
+        addSlide(AppIntroFragment.newInstanceWithRes(
                 "Explore",
                 "Feel free to explore the rest of the library demo!",
                 imageDrawable = R.drawable.ic_slide4))

--- a/example/src/main/java/com/github/appintro/example/ui/permissions/PermissionsIntro.kt
+++ b/example/src/main/java/com/github/appintro/example/ui/permissions/PermissionsIntro.kt
@@ -11,22 +11,22 @@ class PermissionsIntro : AppIntro() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Welcome!",
                 "This is a demo of the AppIntro library, with permissions being requested on a slide!",
                 imageDrawable = R.drawable.ic_slide1))
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Permission Request",
                 "In order to access your camera, you must give permissions.",
                 imageDrawable = R.drawable.ic_slide2))
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Simple, yet Customizable",
                 "The library offers a lot of customization, while keeping it simple for those that like simple.",
                 imageDrawable = R.drawable.ic_slide3))
 
-        addSlide(AppIntroFragment.newInstance(
+        addSlide(AppIntroFragment.newInstance2(
                 "Explore",
                 "Feel free to explore the rest of the library demo!",
                 imageDrawable = R.drawable.ic_slide4))


### PR DESCRIPTION
As we discussed here the PR for #926. I had added 3 new resource parameters for color definitions.

While booth parameter types are from type Integer, I decided to create a `newInstance2(...)` method. I think this is a more cleaner solution while Kotlin does not support deprecation marks on function parameters.

I added deprecation marks for the existing values. But is that the right choice? 
On NavBar and StatusBar color function the library does support both options static color and a resource value:
> // Control the status bar color
> setStatusBarColor(Color.GREEN)
> setStatusBarColorRes(R.color.green)
> 
> // Control the navigation bar color
> setNavBarColor(Color.RED)
> setNavBarColorRes(R.color.red)