### PR TITLE
Add @JvmOverloads on goToNextSlide

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -174,6 +174,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
     }
 
     /** Moves the AppIntro to the next slide */
+    @JvmOverloads
     protected fun goToNextSlide(isLastSlide: Boolean = pager.isLastSlide(fragments.size)) {
         if (isLastSlide) {
             onIntroFinished()


### PR DESCRIPTION
Fixes #955

Currently `goToNextSlide` is not callable from Java because the parameter `isLastSlide` relies on internal logic. Adding `@JvmOverloads` will solve this.
