### PR TITLE
Expose a protected property for slidesNumber

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -99,6 +99,11 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
      * */
     protected var isVibrate = false
 
+    /**
+     * Read-only property with the total number of slides for this AppIntro.
+     */
+    protected val totalSlidesNumber: Int get() = slidesNumber
+
     // Private Fields
 
     private lateinit var pagerAdapter: PagerAdapter


### PR DESCRIPTION
Fixes #954 

I'm exposing a protected read-only property for `slidesNumber`