### PR TITLE
Java example: Use setImmersiveMode instead of setImmersive

### DIFF
--- a/example/src/main/java/com/github/appintro/example/ui/java/JavaIntro.java
+++ b/example/src/main/java/com/github/appintro/example/ui/java/JavaIntro.java
@@ -59,8 +59,8 @@ public class JavaIntro extends AppIntro {
         //Show/hide skip button
         setSkipButtonEnabled(true);
         
-        //Enable/disable immersive mode (no status and nav bar)
-        setImmersive(true);
+        //Enable immersive mode (no status and nav bar)
+        setImmersiveMode();
         
         //Enable/disable page indicators
         setIndicatorEnabled(true);


### PR DESCRIPTION
I accidentally merged this in the Java example. This method calls should be removed as it requires API lvl 18 and is making lint unhappy.