### PR TITLE
Make the descriptions on the intro pages scrollable

### DIFF
--- a/appintro/src/main/res/layout-land/appintro_fragment_intro.xml
+++ b/appintro/src/main/res/layout-land/appintro_fragment_intro.xml
@@ -12,11 +12,14 @@
     <TextView
         android:id="@+id/title"
         style="@style/AppIntroDefaultHeading"
+        app:layout_constraintVertical_weight="1"
+        app:layout_constraintHorizontal_weight="1"
+        android:gravity="center"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:layout_constraintBottom_toTopOf="@+id/description"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/landing_scroll_description"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/midline"
+        app:layout_constraintStart_toEndOf="@+id/image"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="spread"
         tools:text="Welcome" />
@@ -24,31 +27,41 @@
     <ImageView
         android:id="@+id/image"
         style="@style/AppIntroDefaultImage"
+        app:layout_constraintHorizontal_weight="1"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/app_intro_image_content_description"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/midline"
+        app:layout_constraintEnd_toStartOf="@+id/title"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <ScrollView
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:id="@+id/landing_scroll_description"
+        app:layout_constraintVertical_weight="2"
+        app:layout_constraintHorizontal_weight="1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/image"
+        app:layout_constraintTop_toBottomOf="@+id/title"
+        android:fillViewport="true">
     <TextView
         android:id="@+id/description"
         style="@style/AppIntroDefaultText"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:autoLink="web"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/midline"
-        app:layout_constraintTop_toBottomOf="@+id/title"
         tools:text="This is a demo of the AppIntro Library" />
+    </ScrollView>
 
+    <!-- The following guideline code is not used-->
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/midline"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.5" />
+        app:layout_constraintGuide_begin="366dp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/appintro/src/main/res/layout-land/appintro_fragment_intro.xml
+++ b/appintro/src/main/res/layout-land/appintro_fragment_intro.xml
@@ -13,13 +13,12 @@
         android:id="@+id/title"
         style="@style/AppIntroDefaultHeading"
         app:layout_constraintVertical_weight="1"
-        app:layout_constraintHorizontal_weight="1"
         android:gravity="center"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toTopOf="@+id/landing_scroll_description"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/image"
+        app:layout_constraintStart_toEndOf="@+id/midline"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="spread"
         tools:text="Welcome" />
@@ -27,12 +26,11 @@
     <ImageView
         android:id="@+id/image"
         style="@style/AppIntroDefaultImage"
-        app:layout_constraintHorizontal_weight="1"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/app_intro_image_content_description"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/title"
+        app:layout_constraintEnd_toStartOf="@+id/midline"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -41,10 +39,9 @@
         android:layout_height="0dp"
         android:id="@+id/landing_scroll_description"
         app:layout_constraintVertical_weight="2"
-        app:layout_constraintHorizontal_weight="1"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/image"
+        app:layout_constraintStart_toEndOf="@+id/midline"
         app:layout_constraintTop_toBottomOf="@+id/title"
         android:fillViewport="true">
     <TextView
@@ -56,12 +53,11 @@
         tools:text="This is a demo of the AppIntro Library" />
     </ScrollView>
 
-    <!-- The following guideline code is not used-->
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/midline"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_begin="366dp" />
+        app:layout_constraintGuide_percent="0.5" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/appintro/src/main/res/layout/appintro_fragment_intro.xml
+++ b/appintro/src/main/res/layout/appintro_fragment_intro.xml
@@ -30,22 +30,27 @@
         android:layout_height="0dp"
         app:layout_constraintVertical_weight="5"
         android:contentDescription="@string/app_intro_image_content_description"
-        app:layout_constraintBottom_toTopOf="@+id/description"
+        app:layout_constraintBottom_toTopOf="@+id/scrollable_textview"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/title" />
 
-    <TextView
-        android:id="@+id/description"
-        style="@style/AppIntroDefaultText"
+    <ScrollView
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:autoLink="web"
+        android:id="@+id/scrollable_textview"
         app:layout_constraintVertical_weight="3"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/image"
-        tools:text="This is a demo of the AppIntro Library" />
+        app:layout_constraintTop_toBottomOf="@+id/image">
+        <TextView
+            android:id="@+id/description"
+            style="@style/AppIntroDefaultText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:autoLink="web"
+            tools:text="This is a demo of the AppIntro Library" />
+    </ScrollView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Dear developer:

Hello! I am the creator of issue #963, and I have fixed the blocked descriptions to make it more responsive. I would appreciate it if you could kindly revise my code and leave me some advice. Thank you so much for your precious time!

Here are the screenshots after my changes:

<img src="https://user-images.githubusercontent.com/25502419/131212010-072e2a19-6c86-4cdc-bd5d-2ea1eead727d.png" alt="copy" width="250"/> <img src="https://user-images.githubusercontent.com/25502419/131212012-054e7f29-c681-4c78-b977-ca77369a2543.png" alt="copy" width="250"/> <img src="https://user-images.githubusercontent.com/25502419/131212013-44009157-8f54-469d-beef-bd5a59c3084c.png" alt="copy" width="250"/>

Thanks again! Blessings on your day! :)