### PR TITLE
Bump androidx annotations to 1.3.0

### DIFF
--- a/appintro/build.gradle
+++ b/appintro/build.gradle
@@ -33,7 +33,7 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'androidx.annotation:annotation:1.2.0'
+    implementation 'androidx.annotation:annotation:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
 
     testImplementation 'junit:junit:4.13.2'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -39,6 +39,6 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.1.1"
     implementation "androidx.core:core-ktx:1.7.0"
     implementation "androidx.recyclerview:recyclerview:1.2.1"
-    implementation 'androidx.annotation:annotation:1.2.0'
+    implementation 'androidx.annotation:annotation:1.3.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
 }


### PR DESCRIPTION
Just noticed that Lint was failing because of this. I'm bumping this dependency.