### PR TITLE
Cache setup-java between builds

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -16,19 +16,12 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
-      - name: Cache Gradle Folders
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/
-          key: cache-gradle
-
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '11'
+          cache: 'gradle'
 
       - name: Run ktlint
         run: ./gradlew ktlintCheck
@@ -41,19 +34,12 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
-      - name: Cache Gradle Folders
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/
-          key: cache-gradle
-
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '11'
+          cache: 'gradle'
 
       - name: Run detekt
         run: ./gradlew detekt
@@ -66,19 +52,12 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
-      - name: Cache Gradle Folders
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/
-          key: cache-gradle
-
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '11'
+          cache: 'gradle'
 
       - name: Run lint
         run: ./gradlew lint
@@ -91,19 +70,12 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
-      - name: Cache Gradle Folders
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/
-          key: cache-gradle
-
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '11'
+          cache: 'gradle'
 
       - name: Run all the tests
         run: ./gradlew test
@@ -144,14 +116,7 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '11'
-
-      - name: Cache Gradle Folders
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/
-          key: cache-gradle
+          cache: 'gradle'
 
       - name: Build the Debug APK
         run: ./gradlew assembleDebug


### PR DESCRIPTION
`actions/setup-java@v2` recently introduced a caching mechanism that uses `actions/cache@v2` internally (https://github.com/actions/setup-java/blob/main/src/cache.ts#L33).

This PR switches from manual `actions/cache@v2` caching to `setup-java` gradle caching implementation.