### PR TITLE
Fix RTL bug on wrongly retained currentItem

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -486,7 +486,13 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
             putBoolean(ARG_BUNDLE_IS_SKIP_BUTTON_ENABLED, isSkipButtonEnabled)
             putBoolean(ARG_BUNDLE_IS_INDICATOR_ENABLED, isIndicatorEnabled)
 
-            putInt(ARG_BUNDLE_CURRENT_ITEM, pager.currentItem)
+            // We can't use pager.currentItem as we need the current item that is RTL-invariant.
+            val currentItem = if (isRtl) {
+                fragments.size - pager.currentItem
+            } else {
+                pager.currentItem
+            }
+            putInt(ARG_BUNDLE_CURRENT_ITEM, currentItem)
             putBoolean(ARG_BUNDLE_IS_FULL_PAGING_ENABLED, pager.isFullPagingEnabled)
 
             putSerializable(ARG_BUNDLE_PERMISSION_MAP, permissionsMap)

--- a/example/src/main/res/layout/item_intro.xml
+++ b/example/src/main/res/layout/item_intro.xml
@@ -15,11 +15,14 @@
 
         <TextView
             android:id="@+id/item_title"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
+            android:layout_marginEnd="@dimen/base_grid_size"
+            android:layout_marginRight="@dimen/base_grid_size"
             android:textAppearance="@style/TextAppearance.AppCompat.Title"
-            app:layout_constraintEnd_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/item_button"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="AppIntro Sample App" />
 


### PR DESCRIPTION
Fixes #995
Closes #997 

This PR is fixing a bug with the RTL and the retention of the ViewPager. I believe this is the root cause of #995. Maybe @rezazarchi can verify that my patch works?

Essentially AppIntro was not correctly saving the current item when on RTL. So rotating the device when on RTL would cause to jump between slides. This PR fixes it.

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/3001957/154600425-e0ffcb98-98e7-4d65-add3-29c03fa271f9.gif) | ![after](https://user-images.githubusercontent.com/3001957/154600437-1c7f8fd7-766a-461b-ac27-17bca2a70229.gif) |

 