### PR TITLE
Handle deprecation of .vibrate()

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -3,12 +3,9 @@
 package com.github.appintro
 
 import android.animation.ArgbEvaluator
-import android.annotation.SuppressLint
-import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
-import android.os.Vibrator
 import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
@@ -32,6 +29,7 @@ import com.github.appintro.internal.AppIntroViewPager
 import com.github.appintro.internal.LayoutUtil
 import com.github.appintro.internal.LogHelper
 import com.github.appintro.internal.PermissionWrapper
+import com.github.appintro.internal.VibrationHelper
 import com.github.appintro.internal.viewpager.PagerAdapter
 import com.github.appintro.internal.viewpager.ViewPagerTransformer
 
@@ -128,8 +126,6 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
 
     private var retainIsButtonsEnabled = true
 
-    // Android SDK
-    private lateinit var vibrator: Vibrator
     private val argbEvaluator = ArgbEvaluator()
 
     internal val isRtl: Boolean
@@ -425,8 +421,6 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
             backButton.scaleX = -1f
         }
 
-        vibrator = this.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
-
         pagerAdapter = PagerAdapter(supportFragmentManager, fragments)
         pager = findViewById(R.id.view_pager)
 
@@ -687,11 +681,9 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         }
     }
 
-    // You must grant vibration permissions on your AndroidManifest.xml file
-    @SuppressLint("MissingPermission")
     private fun dispatchVibration() {
         if (isVibrate) {
-            vibrator.vibrate(vibrateDuration)
+            VibrationHelper.vibrate(this, vibrateDuration)
         }
     }
 

--- a/appintro/src/main/java/com/github/appintro/internal/VibrationHelper.kt
+++ b/appintro/src/main/java/com/github/appintro/internal/VibrationHelper.kt
@@ -1,0 +1,40 @@
+package com.github.appintro.internal
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat.getSystemService
+
+object VibrationHelper {
+
+    private var vibrator: Vibrator? = null
+
+    private fun initializeVibrator(context: Context) {
+        vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val vibratorManager =
+                context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
+            vibratorManager.defaultVibrator
+        } else {
+            @Suppress("DEPRECATION")
+            context.getSystemService(AppCompatActivity.VIBRATOR_SERVICE) as Vibrator
+        }
+    }
+
+    // You must grant vibration permissions on your AndroidManifest.xml file
+    @SuppressLint("MissingPermission")
+    fun vibrate(context: Context, vibrateDuration: Long) {
+        if (vibrator == null) {
+            initializeVibrator(context)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            vibrator?.vibrate(VibrationEffect.createOneShot(vibrateDuration, VibrationEffect.DEFAULT_AMPLITUDE))
+        } else {
+            @Suppress("DEPRECATION")
+            vibrator?.vibrate(vibrateDuration)
+        }
+    }
+}

--- a/example/src/main/java/com/github/appintro/example/ui/java/JavaIntro.java
+++ b/example/src/main/java/com/github/appintro/example/ui/java/JavaIntro.java
@@ -56,9 +56,6 @@ public class JavaIntro extends AppIntro {
         //Activate wizard mode (Some aesthetic changes)
         setWizardMode(true);
         
-        //Show/hide skip button
-        setSkipButtonEnabled(true);
-        
         //Enable immersive mode (no status and nav bar)
         setImmersiveMode();
         
@@ -67,6 +64,9 @@ public class JavaIntro extends AppIntro {
         
         //Dhow/hide ALL buttons
         setButtonsEnabled(true);
+
+        // Enable Vibration
+        setVibrate(true);
     }
 
     @Override


### PR DESCRIPTION
The `.vibrate(long)` is deprecated in favor of
`.vibrate(VibrationEffect)`. I'm handling it here while still keeping the backward compatibility.

Also the `getSystemService(VIBRATOR_SERVICE)` is deprecated, I've provided the correct implementation for this as well.