### PR TITLE
Move the namespace to gradle file

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 android {
     compileSdk = libs.versions.compile.sdk.version.get().toInt()
+    namespace = "com.github.appintro.example"
 
     defaultConfig {
         minSdk = libs.versions.min.sdk.version.get().toInt()

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.appintro.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />


### PR DESCRIPTION
Another round of warnings fixed. We currently have on console:

```
> Task :example:processDebugMainManifest
package="com.github.appintro.example" found in source AndroidManifest.xml: /Users/ncor/oss/AppIntro/example/src/main/AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace
This migration can be done automatically using the AGP Upgrade Assistant, please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.

> Task :example:processReleaseMainManifest
package="com.github.appintro.example" found in source AndroidManifest.xml: /Users/ncor/oss/AppIntro/example/src/main/AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace
This migration can be done automatically using the AGP Upgrade Assistant, please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.
```

This PR addresses it.