### PR TITLE
Fix several compilation warnings

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -244,7 +244,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         ReplaceWith("setSwipeLock"),
         DeprecationLevel.ERROR
     )
-    @Suppress("UnusedPrivateMember")
+    @Suppress("UnusedPrivateMember", "UNUSED_PARAMETER")
     protected fun setNextPageSwipeLock(lock: Boolean) {
         LogHelper.w(
             TAG,
@@ -452,18 +452,10 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         }
 
         pager.post {
-            val fragment = pagerAdapter.getItem(pager.currentItem)
-            // Fragment is null when no slides are passed to AppIntro
-            if (fragment != null) {
-                dispatchSlideChangedCallbacks(
-                    null,
-                    pagerAdapter
-                        .getItem(pager.currentItem)
-                )
-            } else {
-                // Close the intro if there are no slides to show
-                finish()
-            }
+            dispatchSlideChangedCallbacks(
+                null,
+                pagerAdapter.getItem(pager.currentItem)
+            )
         }
     }
 
@@ -503,10 +495,15 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
             savedCurrentItem = getInt(ARG_BUNDLE_CURRENT_ITEM)
             pager.isFullPagingEnabled = getBoolean(ARG_BUNDLE_IS_FULL_PAGING_ENABLED)
 
-            permissionsMap = (
+            @Suppress("UNCHECKED_CAST", "DEPRECATION")
+            permissionsMap = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                (getSerializable(ARG_BUNDLE_PERMISSION_MAP, HashMap::class.java) as HashMap<Int, PermissionWrapper>?)
+                    ?: hashMapOf()
+            } else {
                 (getSerializable(ARG_BUNDLE_PERMISSION_MAP) as HashMap<Int, PermissionWrapper>?)
                     ?: hashMapOf()
-                )
+            }
+
             isColorTransitionsEnabled = getBoolean(ARG_BUNDLE_COLOR_TRANSITIONS_ENABLED)
         }
     }

--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -452,10 +452,15 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         }
 
         pager.post {
-            dispatchSlideChangedCallbacks(
-                null,
-                pagerAdapter.getItem(pager.currentItem)
-            )
+            if (pager.currentItem < pagerAdapter.count) {
+                dispatchSlideChangedCallbacks(
+                    null,
+                    pagerAdapter.getItem(pager.currentItem)
+                )
+            } else {
+                // Close the intro if there are no slides to show
+                finish()
+            }
         }
     }
 

--- a/appintro/src/main/java/com/github/appintro/AppIntroBaseFragment.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBaseFragment.kt
@@ -55,6 +55,10 @@ abstract class AppIntroBaseFragment : Fragment(), SlideSelectionListener, SlideB
     private var descColorRes: Int = 0
 
     @ColorInt
+    @Deprecated(
+        "`defaultBackgroundColor` has been deprecated to support configuration changes",
+        ReplaceWith("defaultBackgroundColorRes")
+    )
     final override var defaultBackgroundColor: Int = 0
         private set
 

--- a/appintro/src/main/java/com/github/appintro/indicator/ProgressIndicatorController.kt
+++ b/appintro/src/main/java/com/github/appintro/indicator/ProgressIndicatorController.kt
@@ -1,10 +1,11 @@
 package com.github.appintro.indicator
 
 import android.content.Context
-import android.graphics.PorterDuff
 import android.util.AttributeSet
 import android.view.View
 import android.widget.ProgressBar
+import androidx.core.graphics.BlendModeColorFilterCompat
+import androidx.core.graphics.BlendModeCompat
 import com.github.appintro.internal.LayoutUtil
 
 internal const val DEFAULT_COLOR = 1
@@ -24,13 +25,21 @@ class ProgressIndicatorController @JvmOverloads constructor(
     override var selectedIndicatorColor = DEFAULT_COLOR
         set(value) {
             field = value
-            progressDrawable.setColorFilter(value, PorterDuff.Mode.SRC_IN)
+            progressDrawable.colorFilter =
+                BlendModeColorFilterCompat.createBlendModeColorFilterCompat(
+                    value,
+                    BlendModeCompat.SRC_ATOP
+                )
         }
 
     override var unselectedIndicatorColor = DEFAULT_COLOR
         set(value) {
             field = value
-            indeterminateDrawable.setColorFilter(value, PorterDuff.Mode.SRC_IN)
+            progressDrawable.colorFilter =
+                BlendModeColorFilterCompat.createBlendModeColorFilterCompat(
+                    value,
+                    BlendModeCompat.SRC_ATOP
+                )
         }
 
     override fun newInstance(context: Context) = this
@@ -47,7 +56,11 @@ class ProgressIndicatorController @JvmOverloads constructor(
     }
 
     override fun selectPosition(index: Int) {
-        this.progress = if (isRtl) { max - index } else { index + 1 }
+        this.progress = if (isRtl) {
+            max - index
+        } else {
+            index + 1
+        }
     }
 
     private val isRtl: Boolean get() = LayoutUtil.isRtl(this.context)


### PR DESCRIPTION
Another round of warnings that we can get rid of:
- `getSerializable(String)` was deprecated in API 33, now we need to use `getSerializable(String, Class)`.
- `defaultBackgroundColor` was overriding a deprecated API without re-declaring the deprecation
- `setColorFilter(Int, PorterDuff.Mode)` is deprecated in favor of `setColorFilter(ColorFilter)`. I've used a compat method from Androidx here to solve this deprecation.