### PR TITLE
Fix warning for support library requestWindowFeature

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -383,7 +383,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
      =================================== */
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        requestWindowFeature(Window.FEATURE_NO_TITLE)
+        supportRequestWindowFeature(Window.FEATURE_NO_TITLE)
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
         super.onCreate(savedInstanceState)
 


### PR DESCRIPTION
Fix compiler warning since `requestWindowFeature` is called instead of `supportRequestWindowFeature` in an `AppCompatActivity`.