### PR TITLE
Reintroduce target sdk in example app

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -9,6 +9,7 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.min.sdk.version.get().toInt()
+        targetSdk = libs.versions.target.sdk.version.get().toInt()
 
         vectorDrawables.useSupportLibrary = true
         applicationId = "com.github.appintro.example"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ ktlint_gradle = "11.5.0"
 min_sdk_version = "14"
 mockito_core = "5.4.0"
 recyclerview = "1.3.0"
+target_sdk_version = "33"
 
 [libraries]
 androidx_annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }


### PR DESCRIPTION
My bad, during the review of #1110 I didn't notice that `targetSdk` was also removed from the example app. This results in Android applying compatibility mode for the app.

Only the library target SDK should be deprecated and removed.