### PR TITLE
Deprecate setScrollDurationFactor

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -302,10 +302,12 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
      * multiply duration
      * @param factor the new factor that will be applied to the scroll - default: 1
      */
-    @Deprecated("""
+    @Deprecated(
+        """
         Newer versions of ViewPager do not support customizing scroll duration anymore.
         Expect this method to be removed on future versions of AppIntro.
-    """)
+    """
+    )
     protected fun setScrollDurationFactor(factor: Int) {
         pager.setScrollDurationFactor(factor.toDouble())
     }

--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -302,6 +302,10 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
      * multiply duration
      * @param factor the new factor that will be applied to the scroll - default: 1
      */
+    @Deprecated("""
+        Newer versions of ViewPager do not support customizing scroll duration anymore.
+        Expect this method to be removed on future versions of AppIntro.
+    """)
     protected fun setScrollDurationFactor(factor: Int) {
         pager.setScrollDurationFactor(factor.toDouble())
     }
@@ -382,6 +386,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
      LIFECYCLE
      =================================== */
 
+    @Suppress("DEPRECATION")
     override fun onCreate(savedInstanceState: Bundle?) {
         supportRequestWindowFeature(Window.FEATURE_NO_TITLE)
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)

--- a/example/src/main/java/com/github/appintro/example/ui/java/JavaIntro.java
+++ b/example/src/main/java/com/github/appintro/example/ui/java/JavaIntro.java
@@ -44,9 +44,6 @@ public class JavaIntro extends AppIntro {
         // Show/hide status bar
         showStatusBar(true);
         
-        //Speed up or down scrolling
-        setScrollDurationFactor(2);
-        
         //Enable the color "fade" animation between two slides (make sure the slide implements SlideBackgroundColorHolder)
         setColorTransitionsEnabled(true);
         


### PR DESCRIPTION
As discussed in #1112, this PR adds a deprecation warning to `setScrollDurationFactor` and removes it from the example intro.