### PR TITLE
Fix askForPermission's not required permissions on API>=30. Closes #141

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -673,18 +673,18 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
             // Permission is denied for the first time (never ask again box is not checked).
             // Ask again explaining the usage of the permission (Show an AlertDialog or Snackbar)
             onUserDeniedPermission(permission)
-
-            // If the permission was not required, we can remove it from the App and let the user proceed.
-            permissionsMap[currentSlideNumber]?.let { requestedPermission ->
-                if (!requestedPermission.required) {
-                    permissionsMap.remove(requestedPermission.position)
-                    goToNextSlide()
-                }
-            }
         } else {
             // Permission is disabled (never ask again is checked)
             // Ask the user to go to settings to enable permission.
             onUserDisabledPermission(permission)
+        }
+
+        // If the permission was not required, we can remove it from the App and let the user proceed.
+        permissionsMap[currentSlideNumber]?.let { requestedPermission ->
+            if (!requestedPermission.required) {
+                permissionsMap.remove(requestedPermission.position)
+                goToNextSlide()
+            }
         }
     }
 


### PR DESCRIPTION
After a [platform behavior change](https://developer.android.com/about/versions/11/privacy/permissions#dialog-visibility), `required=false` value ignored on API >= 30 when the user denies a permission multiple times.

This PR checks if the asked permission is not required even when the request is automatically dismissed by the OS as "don't ask again".