### PR TITLE
Allow AppIntroFragment to be extended

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroFragment.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroFragment.kt
@@ -7,7 +7,7 @@ import androidx.annotation.FontRes
 import com.github.appintro.model.SliderPage
 
 @Suppress("LongParameterList")
-class AppIntroFragment : AppIntroBaseFragment() {
+open class AppIntroFragment : AppIntroBaseFragment() {
 
     override val layoutId: Int get() = R.layout.appintro_fragment_intro
 


### PR DESCRIPTION
This "opens" up the AppIntroFragment. If developers can extend the slide-fragments for more functionality. (Eg. changing the layout easily, or adding code specific for each fragment)