### PR TITLE
Do not read background drawable if it is has not been set

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBaseFragment.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBaseFragment.kt
@@ -51,7 +51,10 @@ abstract class AppIntroBaseFragment : Fragment(), SlideSelectionListener, SlideB
             viewModel.drawable = args.getInt(ARG_DRAWABLE)
             viewModel.title = args.getCharSequence(ARG_TITLE)
             viewModel.description = args.getCharSequence(ARG_DESC)
-            viewModel.bgDrawable = args.getInt(ARG_BG_DRAWABLE)
+
+            if (args.containsKey(ARG_BG_DRAWABLE)) {
+                viewModel.bgDrawable = args.getInt(ARG_BG_DRAWABLE)
+            }
 
             viewModel.titleTypefaceUrl = args.getString(ARG_TITLE_TYPEFACE_URL)
             viewModel.titleTypefaceRes = args.getInt(ARG_TITLE_TYPEFACE_RES)


### PR DESCRIPTION
Template background was read from the bundle, even if not set.
If it has not been set in the bundle, `viewModel.bgDrawable` was set to 0, and when setting the template background a few lines below, it was never null and the defaultBackgroundColorRes was never used.

 ```
     when {
            bgDrawable != null -> {
                mainLayout?.setBackgroundResource(bgDrawable)
            }
            defaultBackgroundColorRes != 0 -> {
                mainLayout?.setBackgroundColor(ContextCompat.getColor(requireContext(), defaultBackgroundColorRes))
            }
            else -> {
                @Suppress("DEPRECATION")
                mainLayout?.setBackgroundColor(defaultBackgroundColor)
            }
        }
```

I just added a check before reading the value from the bundle.