### PR TITLE
Add .kotlin to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ captures/
 .idea/
 
 .DS_Store
+
+# Kotlin
+.kotlin


### PR DESCRIPTION
Since Kotlin 2.0.0, a new folder `.kotlin` folder is generated at compile time.
This PR makes sure it doesn't get added in VC.