### PR TITLE
Prepare for 7.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,40 @@
 ## Version 7.0.0 *(YYYY-MM-DD)*
 This is a new major release of AppIntro. Please note that this release contains multiple new features (see below), several bugfixes, as well as multiple breaking changes.
 
+Visit our for [6.x to 7.x Migration Guide](migrating-from-6.0.md) for more information.
+
 ### Summary of Changes
 * [#1112] We migrated AppIntro from ViewPager to ViewPager2
+* [#1139] Target SDK is now 34
+* [#1216] Min SDK is now 21
 
 ### Breaking Changes
 * We removed `setScrollDurationFactor` since customizing scroll duration is supported anymore on ViewPager2
 * `setCustomTransformer` accepts a `ViewPager2.PageTransformer` instead of `ViewPager.PageTransformer`
+* [#1216] Min SDK bumped from 14 to 21. This [is required](https://developer.android.com/jetpack/androidx/versions/all-channel) to keep receiving JetPack libraries updates.
+
+### Enhancements 🎁
+* [#1133] Added support for spannable text in SliderPage
+* [#1179] Added `setBarMargin` API
+
+### Translations 🌍
+* [#1170] Updated Hungarian translation
+* [#1148] Updated Brazilian Portuguese translation
+
+### Dependency updates 📦
+* Kotlin to 2.0.0
+* AGP to 8.5.0
+* AppCompat to 1.6.1
+* ConstraintLayout to 2.1.4
+* Viewpager2 to 1.1.0
+
+### Bugfixes 🐛
+* [#1143] Fix askForPermission's not required permissions on API>=30
+* [#1202] Do not read background drawable if it is has not been set
+
+### Credits
+This release was possible thanks to the contribution of:
+[@fejese](https://github.com/fejese) [@ArnyminerZ](https://github.com/ArnyminerZ) [@guifxb](https://github.com/guifxb) [@vernazza](https://github.com/vernazza) [@cortinico](https://github.com/cortinico) [@paolorotolo](https://github.com/paolorotolo)
 
 ## Version 6.3.1 *(2023-07-24)*
 This release of AppIntro is identical to 6.3.0. An outdated JitPack configuration caused 6.3.0 not to build correctly.
@@ -33,7 +61,7 @@ This is a new minor release of AppIntro. This library comes with several new fea
 
 ### Dependency updates 📦
 * Kotlin to 1.9.0
-* AGP to 8.0.2
+* AGP to 8.3.2
 * AppCompat to 1.6.1
 * ConstraintLayout to 2.1.4
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ repositories {
 ```groovy
 dependencies {
     // AndroidX Capable version
-    implementation 'com.github.AppIntro:AppIntro:6.3.1'
+    implementation 'com.github.AppIntro:AppIntro:7.0.0'
     
     // *** OR ***
     
@@ -125,7 +125,7 @@ You can find many examples in java language in the [examples directory](example/
 
 ## Migrating 🚗
 
-If you're migrating **from AppIntro v5.x to v6.x**, please expect multiple breaking changes. You can find documentation on how to update your code on this other [migration guide](/docs/migrating-from-5.0.md).
+If you're migrating between major versions, please expect breaking changes. You can find documentation on how to update your code on this other [migration guide](/docs/migrating-from-5.0.md).
 
 ## Features 🧰
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,5 +9,5 @@ The full changelog is available in the [CHANGELOG](/CHANGELOG.md) page. Please v
 ## Migration guides
 
 If you need support migrating from older versions please read:
-
+* [Migrating from 6.x to 7.x](migrating-from-6.0.md)
 * [Migrating from 5.x to 6.x](migrating-from-5.0.md)

--- a/docs/migrating-from-6.0.md
+++ b/docs/migrating-from-6.0.md
@@ -1,0 +1,67 @@
+# Migrating from AppIntro 5.x to 6.x
+
+Please refer to this page if you're **migrating from AppIntro version
+`6.x` to `7.x`**.
+
+AppIntro `7.x` is based on ViewPager2 instead of ViewPager, since the latter isn't in 
+active development anymore.
+
+As a result, of this change, some APIs are changed or not supported anymore. 
+Here's summary of all the breaking changes that you potentially need to fix.
+
+## Custom Transformers
+Custom Transformers are used to animate slide transitions with custom logic.
+If you were using this API, you need to specify a `ViewPager2.PageTransformer` instead of a `ViewPager.PageTransformer`.
+
+The migration from `ViewPage.PageTransformer` to `ViewPager2.PageTransformer` is straightforward
+as shown in the example below.
+
+AppIntro `6.x.x`:
+```kotlin
+import androidx.viewpager.widget.ViewPager
+
+class ExampleCustomTransformer: ViewPager.PageTransformer {
+    override fun transformPage(page: View, position: Float) {
+        // ...
+    }
+}
+
+class DefaultIntro : AppIntro() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setCustomTransformer(ExampleCustomTransformer())
+    }
+}
+```
+
+AppIntro `7.x.x`:
+```kotlin
+import androidx.viewpager2.widget.ViewPager2
+
+class ExampleCustomTransformer: ViewPager2.PageTransformer {
+    override fun transformPage(page: View, position: Float) {
+        // ...
+    }
+}
+
+class DefaultIntro : AppIntro() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setCustomTransformer(ExampleCustomTransformer())
+    }
+}
+```
+
+## Custom Scroll Duration Factor
+`setScrollDurationFactor`, which was already deprecated starting from AppIntro `6.3.0` has been removed.
+This is a consequence of a [limitation of ViewModel2](https://issuetracker.google.com/issues/122656759).
+
+## Summary
+Here's a summary of the breaking changes:
+
+| Removed                                           | Replace With                                       |
+|:--------------------------------------------------|:---------------------------------------------------|
+| `setCustomTransformer(ViewPager.PageTransformer)` | `setCustomTransformer(ViewPager2.PageTransformer)` |
+| `setScrollDurationFactor(factor)`                 | Feature removed                                    |


### PR DESCRIPTION
ViewPager2 `1.1.0` is now [stable](https://developer.android.com/jetpack/androidx/releases/viewpager2#1.1.0)! 🥳 

We can start preparing for a major AppIntro `7.0.0` release 🚀 

This PR updates `README`, `CHANGELOG` and adds a Migration guide from 6.x.x.

PRs that need to be merged before release:
 * [#1216] To allow updating to ViewPager2 `1.1.0` stable
 * [#1199] ViewPager2 version bump from beta to stable
 * Other dependency updates after minSdkVersion increase

