### PR TITLE
Change deprecated WindowInset Behavior

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -226,7 +226,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         if (show) {
             controller.show(systemBars())
         } else {
-            controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_SWIPE
+            controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
             controller.hide(systemBars())
         }
     }


### PR DESCRIPTION
`WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_SWIPE` [was deprecated](https://android-review.googlesource.com/c/platform/frameworks/support/+/2375473) in AndroidX Core [1.10.0](https://developer.android.com/jetpack/androidx/releases/core#1.10.0) and replaced by `BEHAVIOR_DEFAULT`.

This PR switches to `BEHAVIOR_DEFAULT` to make lint happy :)