### PR TITLE
Adapt build scripts to publish on Maven Central

### DIFF
--- a/appintro/build.gradle.kts
+++ b/appintro/build.gradle.kts
@@ -3,11 +3,12 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.detekt)
     alias(libs.plugins.ktlint)
-    id("maven-publish")
+    `maven-publish`
+    signing
 }
 
-group = "com.github.AppIntro"
-version = "7.0.0-beta02"
+group = "dev.appintro"
+version = "7.0.0-SNAPSHOT"
 
 android {
     namespace = "com.github.appintro"
@@ -79,38 +80,57 @@ val POM_URL: String by project
 
 publishing {
     publications {
-        register<MavenPublication>("release") {
-            afterEvaluate {
+        afterEvaluate {
+            register<MavenPublication>("release") {
                 from(components["release"])
-            }
-            pom {
-                name.set(POM_NAME)
-                description.set(POM_DESCRIPTION)
-                url.set(POM_URL)
-                licenses {
-                    license {
-                        name.set(POM_LICENSE_NAME)
-                        url.set(POM_LICENSE_URL)
-                    }
-                }
-                scm {
-                    connection.set(POM_SCM_CONNECTION)
-                    developerConnection.set(POM_SCM_CONNECTION)
+
+                pom {
+                    name.set(POM_NAME)
+                    description.set(POM_DESCRIPTION)
                     url.set(POM_URL)
-                }
-                developers {
-                    developer {
-                        id.set("paolorotolo")
-                        name.set("Paolo Rotolo")
-                        email.set("paolo@rotolo.dev")
+                    licenses {
+                        license {
+                            name.set(POM_LICENSE_NAME)
+                            url.set(POM_LICENSE_URL)
+                        }
                     }
-                    developer {
-                        id.set("cortinico")
-                        name.set("Nicola Corti")
-                        email.set("corti.nico@gmail.com")
+                    scm {
+                        connection.set(POM_SCM_CONNECTION)
+                        developerConnection.set(POM_SCM_CONNECTION)
+                        url.set(POM_URL)
+                    }
+                    developers {
+                        developer {
+                            id.set("paolorotolo")
+                            name.set("Paolo Rotolo")
+                            email.set("rotolopao@gmail.com")
+                        }
+                        developer {
+                            id.set("cortinico")
+                            name.set("Nicola Corti")
+                            email.set("corti.nico@gmail.com")
+                        }
                     }
                 }
             }
         }
+    }
+
+    repositories {
+        maven {
+            name = "OSSRH"
+            url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+
+            credentials {
+                username = project.findProperty("OSS_USERNAME") as String?
+                password = project.findProperty("OSS_PASSWORD") as String?
+            }
+        }
+    }
+}
+
+signing {
+    afterEvaluate {
+        sign(publishing.publications["release"])
     }
 }


### PR DESCRIPTION
Since we've got `dev.appintro` approved into OSSRH, this PR adds the logic in `build.gradle` to publish to `mavenCentral`.

### Testing
Publish a new SNAPSHOT with `gradle publish`.

To test if it's possible to consume it, add Sonatype Snapshot repository:
```kotlin
   maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")}
```

Add AppIntro dependency:
```kotlin
   implementation("dev.appintro.appintro:appintro:7.0.0-SNAPSHOT")
```

### Future Developments
Right now, no automation is set. It would be nice to have a GH Action that automatically publishes SNAPSHOTS or releases.


Closes #1219.